### PR TITLE
trivyアクションを再度有効にした

### DIFF
--- a/.github/workflows/trivy-scanning.yml
+++ b/.github/workflows/trivy-scanning.yml
@@ -3,12 +3,12 @@ name: "Trivy Scanning - Action"
 
 on:
   workflow_dispatch:
-  # push:
-  #   branches: [ master, develop ]
-  # pull_request:
-  #   branches: [ master, develop ]
-  # schedule:
-  #   - cron: "30 1 * * 0"
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
+  schedule:
+    - cron: "30 1 * * 0"
 
 jobs:
   Trivy-Scan:


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/trivy-scanning.yml` file to re-enable the Trivy scanning workflow for various events.

Changes to workflow events:

* [`.github/workflows/trivy-scanning.yml`](diffhunk://#diff-88bf357045685ac81c24c847114637d5dff41f35d5843b9900436d0784974ee3L6-R11): Re-enabled the Trivy scanning workflow for `push`, `pull_request`, and `schedule` events.