### PR TITLE
Dynamo DBをオンデマンドキャパシティに変更

### DIFF
--- a/packages/backend-app/serverless.yml
+++ b/packages/backend-app/serverless.yml
@@ -129,9 +129,7 @@ resources:
         KeySchema:
           - AttributeName: connectionId
             KeyType: HASH
-        ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
+        BillingMode: PAY_PER_REQUEST
     CasualMatchEntriesTable:
       Type: 'AWS::DynamoDB::Table'
       Properties:
@@ -142,9 +140,7 @@ resources:
         KeySchema:
           - AttributeName: userID
             KeyType: HASH
-        ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
+        BillingMode: PAY_PER_REQUEST
     BattleCommandsTable:
       Type: 'AWS::DynamoDB::Table'
       Properties:
@@ -155,9 +151,7 @@ resources:
         KeySchema:
           - AttributeName: userID
             KeyType: HASH
-        ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
+        BillingMode: PAY_PER_REQUEST
     BattlesTable:
       Type: 'AWS::DynamoDB::Table'
       Properties:
@@ -168,9 +162,7 @@ resources:
         KeySchema:
           - AttributeName: battleID
             KeyType: HASH
-        ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
+        BillingMode: PAY_PER_REQUEST
     PrivateMatchRoomsTable:
       Type: 'AWS::DynamoDB::Table'
       Properties:
@@ -181,9 +173,7 @@ resources:
         KeySchema:
           - AttributeName: owner
             KeyType: HASH
-        ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
+        BillingMode: PAY_PER_REQUEST
     PrivateMatchEntriesTable:
       Type: 'AWS::DynamoDB::Table'
       Properties:
@@ -198,9 +188,7 @@ resources:
             KeyType: HASH
           - AttributeName: userID
             KeyType: RANGE
-        ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
+        BillingMode: PAY_PER_REQUEST
   Outputs:
     WebsocketApiId:
       Description: "id of websocket api gateway"


### PR DESCRIPTION
This pull request includes changes to the DynamoDB table configurations in the `packages/backend-app/serverless.yml` file. The primary change is the switch from `ProvisionedThroughput` to `BillingMode: PAY_PER_REQUEST` for several tables.

Changes to DynamoDB table configurations:

* [`CasualMatchEntriesTable`](diffhunk://#diff-0ab90b9017db984688e7f2a6ec4d9312465145315aab60daef088caadb4b677dL132-R132): Changed from `ProvisionedThroughput` to `BillingMode: PAY_PER_REQUEST`.
* [`BattleCommandsTable`](diffhunk://#diff-0ab90b9017db984688e7f2a6ec4d9312465145315aab60daef088caadb4b677dL145-R143): Changed from `ProvisionedThroughput` to `BillingMode: PAY_PER_REQUEST`.
* [`BattlesTable`](diffhunk://#diff-0ab90b9017db984688e7f2a6ec4d9312465145315aab60daef088caadb4b677dL158-R154): Changed from `ProvisionedThroughput` to `BillingMode: PAY_PER_REQUEST`.
* [`PrivateMatchRoomsTable`](diffhunk://#diff-0ab90b9017db984688e7f2a6ec4d9312465145315aab60daef088caadb4b677dL171-R165): Changed from `ProvisionedThroughput` to `BillingMode: PAY_PER_REQUEST`.
* [`PrivateMatchEntriesTable`](diffhunk://#diff-0ab90b9017db984688e7f2a6ec4d9312465145315aab60daef088caadb4b677dL184-R176): Changed from `ProvisionedThroughput` to `BillingMode: PAY_PER_REQUEST`.
* Additional table configuration: Changed from `ProvisionedThroughput` to `BillingMode: PAY_PER_REQUEST`.