### PR TITLE
1.16.11リリース

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9622,13 +9622,13 @@
       }
     },
     "node_modules/gbraver-burst-core": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/gbraver-burst-core/-/gbraver-burst-core-1.32.1.tgz",
-      "integrity": "sha512-FXIO4None1wqGhs7nWYRtv4mnJQzU0Hloq0FWpez9nqnUrR/BkrQYhF4Nh6wZ0vjcPrbQ6z//T8sFF+QRCnuXA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/gbraver-burst-core/-/gbraver-burst-core-1.33.0.tgz",
+      "integrity": "sha512-GaOr/i/75YyVRc7lJsChkPPIXNlj7o/DIrMrzLf+sWeZ8vGgLuBj9r9qKUezsgVWn+YxminhRBjRLu6nkC+76g==",
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.30.1",
-        "zod": "^3.23.8"
+        "zod": "^3.24.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -16333,7 +16333,7 @@
         "@aws-sdk/signature-v4-crt": "^3.712.0",
         "aws-jwt-verify": "^4.0.1",
         "dotenv": "^16.4.7",
-        "gbraver-burst-core": "^1.32.1",
+        "gbraver-burst-core": "^1.33.0",
         "nanoid": "^5.0.9",
         "ramda": "^0.30.1",
         "rimraf": "^6.0.1",
@@ -16949,7 +16949,7 @@
       "license": "MIT",
       "dependencies": {
         "aws-amplify": "^6.10.3",
-        "gbraver-burst-core": "^1.32.1",
+        "gbraver-burst-core": "^1.33.0",
         "rxjs": "^7.8.1",
         "zod": "^3.24.1"
       },
@@ -17328,7 +17328,7 @@
       "dependencies": {
         "@gbraver-burst-network/browser-sdk": "*",
         "dotenv": "^16.4.7",
-        "gbraver-burst-core": "^1.32.1"
+        "gbraver-burst-core": "^1.33.0"
       },
       "devDependencies": {
         "dependency-cruiser": "^16.8.0",

--- a/packages/aws-vpc/CHANGELOG.md
+++ b/packages/aws-vpc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/aws-vpc
 
+## 1.16.11
+
+### Patch Changes
+
+- gbraver-burst-coreをアップデートした
+
 ## 1.16.10
 
 ### Patch Changes

--- a/packages/aws-vpc/package.json
+++ b/packages/aws-vpc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/aws-vpc",
   "description": "gbraver burst backend vpc.",
-  "version": "1.16.10",
+  "version": "1.16.11",
   "bin": {
     "aws-vpc": "bin/aws-vpc.js"
   },

--- a/packages/backend-app/CHANGELOG.md
+++ b/packages/backend-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/backend-app
 
+## 1.16.11
+
+### Patch Changes
+
+- gbraver-burst-coreをアップデートした
+
 ## 1.16.10
 
 ### Patch Changes

--- a/packages/backend-app/package.json
+++ b/packages/backend-app/package.json
@@ -11,7 +11,7 @@
     "@aws-sdk/signature-v4-crt": "^3.712.0",
     "aws-jwt-verify": "^4.0.1",
     "dotenv": "^16.4.7",
-    "gbraver-burst-core": "^1.32.1",
+    "gbraver-burst-core": "^1.33.0",
     "nanoid": "^5.0.9",
     "ramda": "^0.30.1",
     "rimraf": "^6.0.1",

--- a/packages/backend-app/package.json
+++ b/packages/backend-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/backend-app",
   "description": "gbraver burst backend app",
-  "version": "1.16.10",
+  "version": "1.16.11",
   "author": "Y.Takeuchi",
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.712.0",

--- a/packages/backend-app/test/src/core/__snapshots__/progress-battle.test.ts.snap
+++ b/packages/backend-app/test/src/core/__snapshots__/progress-battle.test.ts.snap
@@ -888,13 +888,21 @@ exports[`バトル進行の結果、バトル継続となる 1`] = `
                   "type": "BATTERY_COMMAND",
                 },
                 {
+                  "battery": 4,
+                  "type": "BATTERY_COMMAND",
+                },
+                {
+                  "battery": 5,
+                  "type": "BATTERY_COMMAND",
+                },
+                {
                   "type": "BURST_COMMAND",
                 },
                 {
                   "type": "PILOT_SKILL_COMMAND",
                 },
               ],
-              "playerId": "attacker-player-id",
+              "playerId": "defender-player",
               "selectable": true,
             },
             {
@@ -916,21 +924,13 @@ exports[`バトル進行の結果、バトル継続となる 1`] = `
                   "type": "BATTERY_COMMAND",
                 },
                 {
-                  "battery": 4,
-                  "type": "BATTERY_COMMAND",
-                },
-                {
-                  "battery": 5,
-                  "type": "BATTERY_COMMAND",
-                },
-                {
                   "type": "BURST_COMMAND",
                 },
                 {
                   "type": "PILOT_SKILL_COMMAND",
                 },
               ],
-              "playerId": "defender-player",
+              "playerId": "attacker-player-id",
               "selectable": true,
             },
           ],
@@ -1378,13 +1378,21 @@ exports[`バトル進行の結果、バトル継続となる 1`] = `
                 "type": "BATTERY_COMMAND",
               },
               {
+                "battery": 4,
+                "type": "BATTERY_COMMAND",
+              },
+              {
+                "battery": 5,
+                "type": "BATTERY_COMMAND",
+              },
+              {
                 "type": "BURST_COMMAND",
               },
               {
                 "type": "PILOT_SKILL_COMMAND",
               },
             ],
-            "playerId": "attacker-player-id",
+            "playerId": "defender-player",
             "selectable": true,
           },
           {
@@ -1406,21 +1414,13 @@ exports[`バトル進行の結果、バトル継続となる 1`] = `
                 "type": "BATTERY_COMMAND",
               },
               {
-                "battery": 4,
-                "type": "BATTERY_COMMAND",
-              },
-              {
-                "battery": 5,
-                "type": "BATTERY_COMMAND",
-              },
-              {
                 "type": "BURST_COMMAND",
               },
               {
                 "type": "PILOT_SKILL_COMMAND",
               },
             ],
-            "playerId": "defender-player",
+            "playerId": "attacker-player-id",
             "selectable": true,
           },
         ],

--- a/packages/backend-ecs/CHANGELOG.md
+++ b/packages/backend-ecs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/backend-ecs
 
+## 1.16.11
+
+### Patch Changes
+
+- gbraver-burst-coreをアップデートした
+
 ## 1.16.10
 
 ### Patch Changes

--- a/packages/backend-ecs/package.json
+++ b/packages/backend-ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/backend-ecs",
   "description": "create backend ecs.",
-  "version": "1.16.10",
+  "version": "1.16.11",
   "bin": {
     "backend-ecs": "bin/backend-ecs.js"
   },

--- a/packages/browser-sdk/CHANGELOG.md
+++ b/packages/browser-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/browser-sdk
 
+## 1.16.11
+
+### Patch Changes
+
+- gbraver-burst-coreをアップデートした
+
 ## 1.16.10
 
 ### Patch Changes

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "aws-amplify": "^6.10.3",
-    "gbraver-burst-core": "^1.32.1",
+    "gbraver-burst-core": "^1.33.0",
     "rxjs": "^7.8.1",
     "zod": "^3.24.1"
   },

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/browser-sdk",
   "description": "gbraver burst browser sdk",
-  "version": "1.16.10",
+  "version": "1.16.11",
   "author": "Y.Takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-network/issues",

--- a/packages/serverless-stub/CHANGELOG.md
+++ b/packages/serverless-stub/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @gbraver-burst-network/serverless-stub
 
+## 1.16.11
+
+### Patch Changes
+
+- gbraver-burst-coreをアップデートした
+- Updated dependencies
+  - @gbraver-burst-network/browser-sdk@1.16.11
+
 ## 1.16.10
 
 ### Patch Changes

--- a/packages/serverless-stub/package.json
+++ b/packages/serverless-stub/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/serverless-stub",
   "description": "gbraver burst network stub.",
-  "version": "1.16.10",
+  "version": "1.16.11",
   "author": "Y.Takeuchi",
   "dependencies": {
     "@gbraver-burst-network/browser-sdk": "*",

--- a/packages/serverless-stub/package.json
+++ b/packages/serverless-stub/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@gbraver-burst-network/browser-sdk": "*",
     "dotenv": "^16.4.7",
-    "gbraver-burst-core": "^1.32.1"
+    "gbraver-burst-core": "^1.33.0"
   },
   "devDependencies": {
     "dependency-cruiser": "^16.8.0",


### PR DESCRIPTION
This pull request includes version updates and dependency updates across multiple packages. The most important changes are as follows:

Version Updates:

* [`packages/aws-vpc/package.json`](diffhunk://#diff-1e1d61e86cebb7496b3ea3d5b51cbbc6a17797a048b7bb331f6105237468e218L4-R4): Updated the version from `1.16.10` to `1.16.11`.
* [`packages/backend-app/package.json`](diffhunk://#diff-e8863e6291315635ed6033580947eab3fd63b3762e026775bedd8df074cb941cL4-R4): Updated the version from `1.16.10` to `1.16.11`.
* [`packages/backend-ecs/package.json`](diffhunk://#diff-d09faa1ceef5d3684323489669d6f26951645a3ea38c71c77d44fa7538db8ba9L4-R4): Updated the version from `1.16.10` to `1.16.11`.
* [`packages/browser-sdk/package.json`](diffhunk://#diff-475fbf96532457ba4b9457941110adacea0f854ef45e19448218936a2086e9dbL4-R12): Updated the version from `1.16.10` to `1.16.11`.
* [`packages/serverless-stub/package.json`](diffhunk://#diff-5f72d91b4238ef7c141e9fe955fcc260b841ecf4c2d33f9f55ee8d36b4ac3f42L4-R9): Updated the version from `1.16.10` to `1.16.11`.

Dependency Updates:

* [`packages/backend-app/package.json`](diffhunk://#diff-e8863e6291315635ed6033580947eab3fd63b3762e026775bedd8df074cb941cL14-R14): Updated `gbraver-burst-core` dependency from `^1.32.1` to `^1.33.0`.
* [`packages/browser-sdk/package.json`](diffhunk://#diff-475fbf96532457ba4b9457941110adacea0f854ef45e19448218936a2086e9dbL4-R12): Updated `gbraver-burst-core` dependency from `^1.32.1` to `^1.33.0`.
* [`packages/serverless-stub/package.json`](diffhunk://#diff-5f72d91b4238ef7c141e9fe955fcc260b841ecf4c2d33f9f55ee8d36b4ac3f42L4-R9): Updated `gbraver-burst-core` dependency from `^1.32.1` to `^1.33.0`.

Changelog Updates:

* [`packages/aws-vpc/CHANGELOG.md`](diffhunk://#diff-a4ee225b383c2e39cb1447ea38ce20f8462216a3de29f8b0ce415c8db3a4685dR3-R8): Added release notes for version `1.16.11`.
* [`packages/backend-app/CHANGELOG.md`](diffhunk://#diff-a70fd3fea3782a67f2de830f3f3000e07ef1eb828347ecd1cb589b79c547779fR3-R8): Added release notes for version `1.16.11`.
* [`packages/backend-ecs/CHANGELOG.md`](diffhunk://#diff-d08b7108571d480cefcf3071e83fc09f4d767089a32b0cfb4a3476ab91e076ecR3-R8): Added release notes for version `1.16.11`.
* [`packages/browser-sdk/CHANGELOG.md`](diffhunk://#diff-fd71b57137241809d8a8c569cb843ce8a29d5ee2705306974c4bb249e8eae4d7R3-R8): Added release notes for version `1.16.11`.
* [`packages/serverless-stub/CHANGELOG.md`](diffhunk://#diff-f012c4416a49f6ab20d64a45dbc6b89868b6d5581dafa1dc0b394e0b21399b08R3-R10): Added release notes for version `1.16.11`.