### PR TITLE
1.16.12リリース

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16101,7 +16101,7 @@
     },
     "packages/aws-vpc": {
       "name": "@gbraver-burst-network/aws-vpc",
-      "version": "1.16.11",
+      "version": "1.16.12",
       "dependencies": {
         "aws-cdk-lib": "^2.173.1",
         "constructs": "^10.4.2",
@@ -16323,7 +16323,7 @@
     },
     "packages/backend-app": {
       "name": "@gbraver-burst-network/backend-app",
-      "version": "1.16.11",
+      "version": "1.16.12",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.712.0",
@@ -16719,7 +16719,7 @@
     },
     "packages/backend-ecs": {
       "name": "@gbraver-burst-network/backend-ecs",
-      "version": "1.16.11",
+      "version": "1.16.12",
       "license": "MIT",
       "dependencies": {
         "@types/ramda": "^0.30.2",
@@ -16945,7 +16945,7 @@
     },
     "packages/browser-sdk": {
       "name": "@gbraver-burst-network/browser-sdk",
-      "version": "1.16.11",
+      "version": "1.16.12",
       "license": "MIT",
       "dependencies": {
         "aws-amplify": "^6.10.3",
@@ -17323,7 +17323,7 @@
     },
     "packages/serverless-stub": {
       "name": "@gbraver-burst-network/serverless-stub",
-      "version": "1.16.11",
+      "version": "1.16.12",
       "license": "MIT",
       "dependencies": {
         "@gbraver-burst-network/browser-sdk": "*",

--- a/packages/aws-vpc/CHANGELOG.md
+++ b/packages/aws-vpc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/aws-vpc
 
+## 1.16.12
+
+### Patch Changes
+
+- gbraver-burst-coreをアップデート
+
 ## 1.16.11
 
 ### Patch Changes

--- a/packages/aws-vpc/package.json
+++ b/packages/aws-vpc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/aws-vpc",
   "description": "gbraver burst backend vpc.",
-  "version": "1.16.11",
+  "version": "1.16.12",
   "bin": {
     "aws-vpc": "bin/aws-vpc.js"
   },

--- a/packages/backend-app/CHANGELOG.md
+++ b/packages/backend-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/backend-app
 
+## 1.16.12
+
+### Patch Changes
+
+- gbraver-burst-coreをアップデート
+
 ## 1.16.11
 
 ### Patch Changes

--- a/packages/backend-app/package.json
+++ b/packages/backend-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/backend-app",
   "description": "gbraver burst backend app",
-  "version": "1.16.11",
+  "version": "1.16.12",
   "author": "Y.Takeuchi",
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.712.0",

--- a/packages/backend-ecs/CHANGELOG.md
+++ b/packages/backend-ecs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/backend-ecs
 
+## 1.16.12
+
+### Patch Changes
+
+- gbraver-burst-coreをアップデート
+
 ## 1.16.11
 
 ### Patch Changes

--- a/packages/backend-ecs/package.json
+++ b/packages/backend-ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/backend-ecs",
   "description": "create backend ecs.",
-  "version": "1.16.11",
+  "version": "1.16.12",
   "bin": {
     "backend-ecs": "bin/backend-ecs.js"
   },

--- a/packages/browser-sdk/CHANGELOG.md
+++ b/packages/browser-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/browser-sdk
 
+## 1.16.12
+
+### Patch Changes
+
+- gbraver-burst-coreをアップデート
+
 ## 1.16.11
 
 ### Patch Changes

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/browser-sdk",
   "description": "gbraver burst browser sdk",
-  "version": "1.16.11",
+  "version": "1.16.12",
   "author": "Y.Takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-network/issues",

--- a/packages/serverless-stub/CHANGELOG.md
+++ b/packages/serverless-stub/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @gbraver-burst-network/serverless-stub
 
+## 1.16.12
+
+### Patch Changes
+
+- gbraver-burst-coreをアップデート
+- Updated dependencies
+  - @gbraver-burst-network/browser-sdk@1.16.12
+
 ## 1.16.11
 
 ### Patch Changes

--- a/packages/serverless-stub/package.json
+++ b/packages/serverless-stub/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/serverless-stub",
   "description": "gbraver burst network stub.",
-  "version": "1.16.11",
+  "version": "1.16.12",
   "author": "Y.Takeuchi",
   "dependencies": {
     "@gbraver-burst-network/browser-sdk": "*",


### PR DESCRIPTION
This pull request includes version updates and changelog entries for multiple packages in the `gbraver-burst-network` project. The changes primarily focus on updating the version numbers and documenting the updates in the changelog files.

Version updates:

* [`packages/aws-vpc/package.json`](diffhunk://#diff-1e1d61e86cebb7496b3ea3d5b51cbbc6a17797a048b7bb331f6105237468e218L4-R4): Updated version from `1.16.11` to `1.16.12`.
* [`packages/backend-app/package.json`](diffhunk://#diff-e8863e6291315635ed6033580947eab3fd63b3762e026775bedd8df074cb941cL4-R4): Updated version from `1.16.11` to `1.16.12`.
* [`packages/backend-ecs/package.json`](diffhunk://#diff-d09faa1ceef5d3684323489669d6f26951645a3ea38c71c77d44fa7538db8ba9L4-R4): Updated version from `1.16.11` to `1.16.12`.
* [`packages/browser-sdk/package.json`](diffhunk://#diff-475fbf96532457ba4b9457941110adacea0f854ef45e19448218936a2086e9dbL4-R4): Updated version from `1.16.11` to `1.16.12`.
* [`packages/serverless-stub/package.json`](diffhunk://#diff-5f72d91b4238ef7c141e9fe955fcc260b841ecf4c2d33f9f55ee8d36b4ac3f42L4-R4): Updated version from `1.16.11` to `1.16.12`.

Changelog entries:

* [`packages/aws-vpc/CHANGELOG.md`](diffhunk://#diff-a4ee225b383c2e39cb1447ea38ce20f8462216a3de29f8b0ce415c8db3a4685dR3-R8): Added entry for version `1.16.12` noting the update of `gbraver-burst-core`.
* [`packages/backend-app/CHANGELOG.md`](diffhunk://#diff-a70fd3fea3782a67f2de830f3f3000e07ef1eb828347ecd1cb589b79c547779fR3-R8): Added entry for version `1.16.12` noting the update of `gbraver-burst-core`.
* [`packages/backend-ecs/CHANGELOG.md`](diffhunk://#diff-d08b7108571d480cefcf3071e83fc09f4d767089a32b0cfb4a3476ab91e076ecR3-R8): Added entry for version `1.16.12` noting the update of `gbraver-burst-core`.
* [`packages/browser-sdk/CHANGELOG.md`](diffhunk://#diff-fd71b57137241809d8a8c569cb843ce8a29d5ee2705306974c4bb249e8eae4d7R3-R8): Added entry for version `1.16.12` noting the update of `gbraver-burst-core`.
* [`packages/serverless-stub/CHANGELOG.md`](diffhunk://#diff-f012c4416a49f6ab20d64a45dbc6b89868b6d5581dafa1dc0b394e0b21399b08R3-R10): Added entry for version `1.16.12` noting the update of `gbraver-burst-core` and updated dependencies.