### PR TITLE
npmパッケージアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5913,9 +5913,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "version": "22.10.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.3.tgz",
+      "integrity": "sha512-DifAyw4BkrufCILvD3ucnuN8eydUfc/C1GlyrnI+LK6543w5/L3VeVgf05o3B4fqSXP1dKYLOZsKfutpxPzZrw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -6772,9 +6772,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.173.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.2.tgz",
-      "integrity": "sha512-qyMU4FoRJdZDUpsOBqyRBALBjf5A2N/MaHKX9iJUkbTET+d+nR07x3ai4TcEES+8pqPFHMTKpQMRDXs9Py/15w==",
+      "version": "2.173.4",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.4.tgz",
+      "integrity": "sha512-zgs3xU28VEKIwHwJHu0ZHeoEmwLGnHS2jPCMc2MsIMZu+a7CKyE77Tw6LwJkuuB96BQyqr6xJB3SbeWjXmcFhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6788,9 +6788,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.173.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.2.tgz",
-      "integrity": "sha512-cL9+z8Pl3VZGoO7BwdsrFAOeud/vSl3at7OvmhihbNprMN15XuFUx/rViAU5OI1m92NbV4NBzYSLbSeCwYLNyw==",
+      "version": "2.173.4",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.4.tgz",
+      "integrity": "sha512-0reN94TzkWmyVZDDBlYB4qzJUig8wTHEe82YLHlWRUhrU78fT+drVGUr+lYZwwETaZ+8fLdCOl9ULvFNq7iczQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -15078,15 +15078,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.18.1.tgz",
-      "integrity": "sha512-Mlaw6yxuaDEPQvb/2Qwu3/TfgeBHy9iTJ3mTwe7OvpPmF6KPQjVOfGyEJpPv6Ez2C34OODChhXrzYw/9phI0MQ==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.19.0.tgz",
+      "integrity": "sha512-Ni8sUkVWYK4KAcTtPjQ/UTiRk6jcsuDhPpxULapUDi8A/l8TSBk+t1GtJA1RsCzIJg0q6+J7bf35AwQigENWRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.18.1",
-        "@typescript-eslint/parser": "8.18.1",
-        "@typescript-eslint/utils": "8.18.1"
+        "@typescript-eslint/eslint-plugin": "8.19.0",
+        "@typescript-eslint/parser": "8.19.0",
+        "@typescript-eslint/utils": "8.19.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -15101,17 +15101,17 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.1.tgz",
-      "integrity": "sha512-Ncvsq5CT3Gvh+uJG0Lwlho6suwDfUXH0HztslDf5I+F2wAFAZMRwYLEorumpKLzmO2suAXZ/td1tBg4NZIi9CQ==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.19.0.tgz",
+      "integrity": "sha512-NggSaEZCdSrFddbctrVjkVZvFC6KGfKfNK0CU7mNK/iKHGKbzT4Wmgm08dKpcZECBu9f5FypndoMyRHkdqfT1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.18.1",
-        "@typescript-eslint/type-utils": "8.18.1",
-        "@typescript-eslint/utils": "8.18.1",
-        "@typescript-eslint/visitor-keys": "8.18.1",
+        "@typescript-eslint/scope-manager": "8.19.0",
+        "@typescript-eslint/type-utils": "8.19.0",
+        "@typescript-eslint/utils": "8.19.0",
+        "@typescript-eslint/visitor-keys": "8.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -15131,16 +15131,16 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.1.tgz",
-      "integrity": "sha512-rBnTWHCdbYM2lh7hjyXqxk70wvon3p2FyaniZuey5TrcGBpfhVp0OxOa6gxr9Q9YhZFKyfbEnxc24ZnVbbUkCA==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.19.0.tgz",
+      "integrity": "sha512-6M8taKyOETY1TKHp0x8ndycipTVgmp4xtg5QpEZzXxDhNvvHOJi5rLRkLr8SK3jTgD5l4fTlvBiRdfsuWydxBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.18.1",
-        "@typescript-eslint/types": "8.18.1",
-        "@typescript-eslint/typescript-estree": "8.18.1",
-        "@typescript-eslint/visitor-keys": "8.18.1",
+        "@typescript-eslint/scope-manager": "8.19.0",
+        "@typescript-eslint/types": "8.19.0",
+        "@typescript-eslint/typescript-estree": "8.19.0",
+        "@typescript-eslint/visitor-keys": "8.19.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -15156,14 +15156,14 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.1.tgz",
-      "integrity": "sha512-HxfHo2b090M5s2+/9Z3gkBhI6xBH8OJCFjH9MhQ+nnoZqxU3wNxkLT+VWXWSFWc3UF3Z+CfPAyqdCTdoXtDPCQ==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.19.0.tgz",
+      "integrity": "sha512-hkoJiKQS3GQ13TSMEiuNmSCvhz7ujyqD1x3ShbaETATHrck+9RaDdUbt+osXaUuns9OFwrDTTrjtwsU8gJyyRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.1",
-        "@typescript-eslint/visitor-keys": "8.18.1"
+        "@typescript-eslint/types": "8.19.0",
+        "@typescript-eslint/visitor-keys": "8.19.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -15174,14 +15174,14 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.1.tgz",
-      "integrity": "sha512-jAhTdK/Qx2NJPNOTxXpMwlOiSymtR2j283TtPqXkKBdH8OAMmhiUfP0kJjc/qSE51Xrq02Gj9NY7MwK+UxVwHQ==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.19.0.tgz",
+      "integrity": "sha512-TZs0I0OSbd5Aza4qAMpp1cdCYVnER94IziudE3JU328YUHgWu9gwiwhag+fuLeJ2LkWLXI+F/182TbG+JaBdTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.18.1",
-        "@typescript-eslint/utils": "8.18.1",
+        "@typescript-eslint/typescript-estree": "8.19.0",
+        "@typescript-eslint/utils": "8.19.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -15198,9 +15198,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.1.tgz",
-      "integrity": "sha512-7uoAUsCj66qdNQNpH2G8MyTFlgerum8ubf21s3TSM3XmKXuIn+H2Sifh/ES2nPOPiYSRJWAk0fDkW0APBWcpfw==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.19.0.tgz",
+      "integrity": "sha512-8XQ4Ss7G9WX8oaYvD4OOLCjIQYgRQxO+qCiR2V2s2GxI9AUpo7riNwo6jDhKtTcaJjT8PY54j2Yb33kWtSJsmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15212,14 +15212,14 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.1.tgz",
-      "integrity": "sha512-z8U21WI5txzl2XYOW7i9hJhxoKKNG1kcU4RzyNvKrdZDmbjkmLBo8bgeiOJmA06kizLI76/CCBAAGlTlEeUfyg==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.19.0.tgz",
+      "integrity": "sha512-WW9PpDaLIFW9LCbucMSdYUuGeFUz1OkWYS/5fwZwTA+l2RwlWFdJvReQqMUMBw4yJWJOfqd7An9uwut2Oj8sLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.1",
-        "@typescript-eslint/visitor-keys": "8.18.1",
+        "@typescript-eslint/types": "8.19.0",
+        "@typescript-eslint/visitor-keys": "8.19.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -15239,16 +15239,16 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.1.tgz",
-      "integrity": "sha512-8vikiIj2ebrC4WRdcAdDcmnu9Q/MXXwg+STf40BVfT8exDqBCUPdypvzcUPxEqRGKg9ALagZ0UWcYCtn+4W2iQ==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.19.0.tgz",
+      "integrity": "sha512-PTBG+0oEMPH9jCZlfg07LCB2nYI0I317yyvXGfxnvGvw4SHIOuRnQ3kadyyXY6tGdChusIHIbM5zfIbp4M6tCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.18.1",
-        "@typescript-eslint/types": "8.18.1",
-        "@typescript-eslint/typescript-estree": "8.18.1"
+        "@typescript-eslint/scope-manager": "8.19.0",
+        "@typescript-eslint/types": "8.19.0",
+        "@typescript-eslint/typescript-estree": "8.19.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -15263,13 +15263,13 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.1.tgz",
-      "integrity": "sha512-Vj0WLm5/ZsD013YeUKn+K0y8p1M0jPpxOkKdbD1wB0ns53a5piVY02zjf072TblEweAbcYiFiPoSMF3kp+VhhQ==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.19.0.tgz",
+      "integrity": "sha512-mCFtBbFBJDCNCWUl5y6sZSCHXw1DEFEk3c/M3nRK2a4XUB8StGFtmcEMizdjKuBzB6e/smJAAWYug3VrdLMr1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.18.1",
+        "@typescript-eslint/types": "8.19.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -16162,9 +16162,9 @@
     },
     "packages/aws-vpc": {
       "name": "@gbraver-burst-network/aws-vpc",
-      "version": "1.16.12",
+      "version": "1.16.13",
       "dependencies": {
-        "aws-cdk-lib": "^2.173.2",
+        "aws-cdk-lib": "^2.173.4",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7",
         "source-map-support": "^0.5.21"
@@ -16174,8 +16174,8 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
-        "@types/node": "22.10.2",
-        "aws-cdk": "2.173.2",
+        "@types/node": "22.10.3",
+        "aws-cdk": "2.173.4",
         "dependency-cruiser": "^16.8.0",
         "eslint": "^9.17.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -16184,7 +16184,7 @@
         "prettier": "3.4.2",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
-        "typescript-eslint": "^8.18.1"
+        "typescript-eslint": "^8.19.0"
       }
     },
     "packages/aws-vpc/node_modules/@eslint/eslintrc": {
@@ -16384,7 +16384,7 @@
     },
     "packages/backend-app": {
       "name": "@gbraver-burst-network/backend-app",
-      "version": "1.16.12",
+      "version": "1.16.13",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.716.0",
@@ -16415,7 +16415,7 @@
         "serverless": "^4.4.18",
         "ts-jest": "^29.2.5",
         "ts-loader": "^9.5.1",
-        "typescript-eslint": "^8.18.1",
+        "typescript-eslint": "^8.19.0",
         "webpack": "^5.97.1",
         "webpack-cli": "^6.0.1"
       }
@@ -16780,11 +16780,11 @@
     },
     "packages/backend-ecs": {
       "name": "@gbraver-burst-network/backend-ecs",
-      "version": "1.16.12",
+      "version": "1.16.13",
       "license": "MIT",
       "dependencies": {
         "@types/ramda": "^0.30.2",
-        "aws-cdk-lib": "^2.173.2",
+        "aws-cdk-lib": "^2.173.4",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7",
         "ramda": "^0.30.1",
@@ -16795,9 +16795,9 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
-        "@types/node": "22.10.2",
+        "@types/node": "22.10.3",
         "@types/uuid": "^10.0.0",
-        "aws-cdk": "2.173.2",
+        "aws-cdk": "2.173.4",
         "dependency-cruiser": "^16.8.0",
         "eslint": "^9.17.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -16806,7 +16806,7 @@
         "prettier": "3.4.2",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
-        "typescript-eslint": "^8.18.1"
+        "typescript-eslint": "^8.19.0"
       }
     },
     "packages/backend-ecs/node_modules/@eslint/eslintrc": {
@@ -17006,7 +17006,7 @@
     },
     "packages/browser-sdk": {
       "name": "@gbraver-burst-network/browser-sdk",
-      "version": "1.16.12",
+      "version": "1.16.13",
       "license": "MIT",
       "dependencies": {
         "aws-amplify": "^6.11.0",
@@ -17025,7 +17025,7 @@
         "prettier": "3.4.2",
         "rimraf": "^6.0.1",
         "ts-jest": "^29.2.5",
-        "typescript-eslint": "^8.18.1",
+        "typescript-eslint": "^8.19.0",
         "webpack": "^5.97.1",
         "webpack-cli": "^6.0.1"
       }
@@ -17384,7 +17384,7 @@
     },
     "packages/serverless-stub": {
       "name": "@gbraver-burst-network/serverless-stub",
-      "version": "1.16.12",
+      "version": "1.16.13",
       "license": "MIT",
       "dependencies": {
         "@gbraver-burst-network/browser-sdk": "*",
@@ -17401,7 +17401,7 @@
         "prettier": "3.4.2",
         "rimraf": "^6.0.1",
         "ts-loader": "^9.5.1",
-        "typescript-eslint": "^8.18.1",
+        "typescript-eslint": "^8.19.0",
         "webpack": "^5.97.1",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.0"

--- a/packages/aws-vpc/package.json
+++ b/packages/aws-vpc/package.json
@@ -6,15 +6,15 @@
     "aws-vpc": "bin/aws-vpc.js"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.173.2",
+    "aws-cdk-lib": "^2.173.4",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "22.10.2",
-    "aws-cdk": "2.173.2",
+    "@types/node": "22.10.3",
+    "aws-cdk": "2.173.4",
     "dependency-cruiser": "^16.8.0",
     "eslint": "^9.17.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -23,7 +23,7 @@
     "prettier": "3.4.2",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
-    "typescript-eslint": "^8.18.1"
+    "typescript-eslint": "^8.19.0"
   },
   "licens": "MIT",
   "private": true,

--- a/packages/backend-app/package.json
+++ b/packages/backend-app/package.json
@@ -32,7 +32,7 @@
     "serverless": "^4.4.18",
     "ts-jest": "^29.2.5",
     "ts-loader": "^9.5.1",
-    "typescript-eslint": "^8.18.1",
+    "typescript-eslint": "^8.19.0",
     "webpack": "^5.97.1",
     "webpack-cli": "^6.0.1"
   },

--- a/packages/backend-ecs/package.json
+++ b/packages/backend-ecs/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@types/ramda": "^0.30.2",
-    "aws-cdk-lib": "^2.173.2",
+    "aws-cdk-lib": "^2.173.4",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7",
     "ramda": "^0.30.1",
@@ -15,9 +15,9 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "22.10.2",
+    "@types/node": "22.10.3",
     "@types/uuid": "^10.0.0",
-    "aws-cdk": "2.173.2",
+    "aws-cdk": "2.173.4",
     "dependency-cruiser": "^16.8.0",
     "eslint": "^9.17.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -26,7 +26,7 @@
     "prettier": "3.4.2",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
-    "typescript-eslint": "^8.18.1"
+    "typescript-eslint": "^8.19.0"
   },
   "license": "MIT",
   "private": true,

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -24,7 +24,7 @@
     "prettier": "3.4.2",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.2.5",
-    "typescript-eslint": "^8.18.1",
+    "typescript-eslint": "^8.19.0",
     "webpack": "^5.97.1",
     "webpack-cli": "^6.0.1"
   },

--- a/packages/serverless-stub/package.json
+++ b/packages/serverless-stub/package.json
@@ -18,7 +18,7 @@
     "prettier": "3.4.2",
     "rimraf": "^6.0.1",
     "ts-loader": "^9.5.1",
-    "typescript-eslint": "^8.18.1",
+    "typescript-eslint": "^8.19.0",
     "webpack": "^5.97.1",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.0"


### PR DESCRIPTION
This pull request includes several dependency updates across multiple packages to ensure compatibility and security. The most significant changes involve updating `aws-cdk-lib`, `aws-cdk`, `@types/node`, and `typescript-eslint` to their latest versions.

Dependency updates:

* Updated `aws-cdk-lib` from `^2.173.2` to `^2.173.4` in `packages/aws-vpc/package.json` and `packages/backend-ecs/package.json`. [[1]](diffhunk://#diff-1e1d61e86cebb7496b3ea3d5b51cbbc6a17797a048b7bb331f6105237468e218L9-R17) [[2]](diffhunk://#diff-d09faa1ceef5d3684323489669d6f26951645a3ea38c71c77d44fa7538db8ba9L10-R20)
* Updated `aws-cdk` from `2.173.2` to `2.173.4` in `packages/aws-vpc/package.json` and `packages/backend-ecs/package.json`. [[1]](diffhunk://#diff-1e1d61e86cebb7496b3ea3d5b51cbbc6a17797a048b7bb331f6105237468e218L9-R17) [[2]](diffhunk://#diff-d09faa1ceef5d3684323489669d6f26951645a3ea38c71c77d44fa7538db8ba9L10-R20)
* Updated `@types/node` from `22.10.2` to `22.10.3` in `packages/aws-vpc/package.json` and `packages/backend-ecs/package.json`. [[1]](diffhunk://#diff-1e1d61e86cebb7496b3ea3d5b51cbbc6a17797a048b7bb331f6105237468e218L9-R17) [[2]](diffhunk://#diff-d09faa1ceef5d3684323489669d6f26951645a3ea38c71c77d44fa7538db8ba9L10-R20)
* Updated `typescript-eslint` from `^8.18.1` to `^8.19.0` in `packages/aws-vpc/package.json`, `packages/backend-app/package.json`, `packages/backend-ecs/package.json`, `packages/browser-sdk/package.json`, and `packages/serverless-stub/package.json`. [[1]](diffhunk://#diff-1e1d61e86cebb7496b3ea3d5b51cbbc6a17797a048b7bb331f6105237468e218L26-R26) [[2]](diffhunk://#diff-e8863e6291315635ed6033580947eab3fd63b3762e026775bedd8df074cb941cL35-R35) [[3]](diffhunk://#diff-d09faa1ceef5d3684323489669d6f26951645a3ea38c71c77d44fa7538db8ba9L29-R29) [[4]](diffhunk://#diff-475fbf96532457ba4b9457941110adacea0f854ef45e19448218936a2086e9dbL27-R27) [[5]](diffhunk://#diff-5f72d91b4238ef7c141e9fe955fcc260b841ecf4c2d33f9f55ee8d36b4ac3f42L21-R21)