### PR TITLE
codeclimateカバレッジ測定ジョブを追加した

### DIFF
--- a/.github/workflows/code-climate.yml
+++ b/.github/workflows/code-climate.yml
@@ -1,0 +1,35 @@
+name: code climate
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 22.x ]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - name: Test & publish code coverage
+      uses: paambaati/codeclimate-action@v9.0.0
+      env:
+        CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+      with:
+        coverageCommand: npm run coverage
+        debug: true
+        coverageLocations: |
+          ${{github.workspace}}/packages/aws-vpc/coverage/lcov.info:lcov
+          ${{github.workspace}}/packages/backend-app/coverage/lcov.info:lcov
+          ${{github.workspace}}/packages/backend-ecs/coverage/lcov.info:lcov
+          ${{github.workspace}}/packages/browser-sdk/coverage/lcov.info:lcov

--- a/Readme.md
+++ b/Readme.md
@@ -151,6 +151,7 @@ npm run build
 
 * serverless dashboardにサインインし、[このページ](https://app.serverless.com/settings/accessKeys)からasccesskeyを生成する
 * AWSで「SlsCli用IAMポリシー」をアタッチしたIAMユーザーを作成し、アクセスキーIDとシークレットキーを控えておく
+* codeclimateのcode climate reporter idを控える
 
 **SlsCli用IAMポリシー**
 
@@ -183,6 +184,7 @@ ActionsのSecretsを設定する。
 | SERVERLESS_ACCESS_KEY | serverless dashboardから発行したaccesskey |
 | AWS_ACCESS_KEY_ID     | AWS IMAユーザー アクセスキーID                |
 | AWS_SECRET_ACCESS_KEY | AWS IMAユーザー シークレットキー                |
+| CC_TEST_REPORTER_ID | code climate reporter id                        |
 
 ### AWS CodeBuild/CodePipelineでCDする
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "clean": "turbo run clean",
     "code-format": "turbo run code-format",
     "code-format-check": "turbo run code-format-check",
+    "coverage": "turbo run coverage",
     "dependency-check": "turbo run dependency-check",
     "lint": "turbo run lint",
     "lint-fix": "turbo run lint-fix",

--- a/packages/aws-vpc/.gitignore
+++ b/packages/aws-vpc/.gitignore
@@ -6,6 +6,7 @@
 node_modules
 .env
 cdk.context.json
+coverage/*
 
 # CDK asset staging directory
 .cdk.staging

--- a/packages/aws-vpc/package.json
+++ b/packages/aws-vpc/package.json
@@ -39,6 +39,7 @@
     "code-format:bin": "prettier --write bin",
     "code-format:lib": "prettier --write lib",
     "code-format:test": "prettier --write test",
+    "coverage": "jest --coverage",
     "dependency-check": "run-s dependency-check:*",
     "dependency-check:bin": "depcruise bin",
     "dependency-check:lib": "depcruise lib",

--- a/packages/backend-app/package.json
+++ b/packages/backend-app/package.json
@@ -51,6 +51,7 @@
     "code-format-check:test": "prettier --check test",
     "code-format:src": "prettier --write src",
     "code-format:test": "prettier --write test",
+    "coverage": "jest --coverage",
     "dependency-check": "run-s dependency-check:*",
     "dependency-check:src": "depcruise src",
     "dependency-check:test": "depcruise test",

--- a/packages/backend-ecs/.gitignore
+++ b/packages/backend-ecs/.gitignore
@@ -5,6 +5,7 @@
 *.d.ts
 node_modules
 .env
+coverage/*
 
 # CDK asset staging directory
 .cdk.staging

--- a/packages/backend-ecs/package.json
+++ b/packages/backend-ecs/package.json
@@ -42,6 +42,7 @@
     "code-format:bin": "prettier --write bin",
     "code-format:lib": "prettier --write lib",
     "code-format:test": "prettier --write test",
+    "coverage": "jest --coverage",
     "dependency-check": "run-s dependency-check:*",
     "dependency-check:bin": "depcruise bin",
     "dependency-check:lib": "depcruise lib",

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -50,6 +50,7 @@
     "code-format-check:test": "prettier --check test",
     "code-format:src": "prettier --write src",
     "code-format:test": "prettier --write test",
+    "coverage": "jest --coverage",
     "dependency-check": "run-s dependency-check:*",
     "dependency-check:src": "depcruise src",
     "dependency-check:test": "depcruise test",

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,10 @@
       "cache": false,
       "env": [ "*" ]
     },
+    "coverage": {
+      "cache": false,
+      "env": [ "*" ]
+    },
     "dependency-check": {
       "cache": false,
       "env": [ "*" ]


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for Code Climate integration, updates documentation, and adds coverage scripts to various package configurations. The most important changes include the addition of the Code Climate workflow, updates to the `Readme.md` for new environment variables, and the inclusion of coverage scripts in multiple `package.json` files.

### Code Climate Integration:

* [`.github/workflows/code-climate.yml`](diffhunk://#diff-bc73f6179757c7f37680c46140388c3e36484ba6408a41c6b267abee0eb92daaR1-R35): Added a new GitHub Actions workflow for Code Climate to run on `develop` branch pushes and pull requests. This workflow sets up Node.js, installs dependencies, and runs tests to publish code coverage results.

### Documentation Updates:

* [`Readme.md`](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031R154): Added instructions to note the Code Climate reporter ID and updated the Actions Secrets section to include `CC_TEST_REPORTER_ID`. [[1]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031R154) [[2]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031R187)

### Coverage Scripts:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17): Added a new `coverage` script to run coverage checks using `turbo`.
* `packages/aws-vpc/package.json`, `packages/backend-app/package.json`, `packages/backend-ecs/package.json`, `packages/browser-sdk/package.json`: Added `coverage` scripts to run Jest with coverage. [[1]](diffhunk://#diff-1e1d61e86cebb7496b3ea3d5b51cbbc6a17797a048b7bb331f6105237468e218R42) [[2]](diffhunk://#diff-e8863e6291315635ed6033580947eab3fd63b3762e026775bedd8df074cb941cR54) [[3]](diffhunk://#diff-d09faa1ceef5d3684323489669d6f26951645a3ea38c71c77d44fa7538db8ba9R45) [[4]](diffhunk://#diff-475fbf96532457ba4b9457941110adacea0f854ef45e19448218936a2086e9dbR53)

### Git Ignore Updates:

* `packages/aws-vpc/.gitignore`, `packages/backend-ecs/.gitignore`: Updated `.gitignore` to exclude coverage directories. [[1]](diffhunk://#diff-02fe78e8f5adc1a520182c517c1fd22825142b3f4739908fed7a53404afef6cfR9) [[2]](diffhunk://#diff-758be06828005020f567f25c1c2db677a073d5ee69a3803438d845d46c69db13R8)

### Turbo Configuration:

* [`turbo.json`](diffhunk://#diff-f8de965273949793edc0fbfe249bb458c0becde39b2e141db087bcbf5d4ad5e3R23-R26): Added a new configuration for the `coverage` script to disable caching and set environment variables.