### PR TITLE
codebuildのnode.jsをv22にした

### DIFF
--- a/buildspec.backendEcs.remove.prod.yml
+++ b/buildspec.backendEcs.remove.prod.yml
@@ -7,7 +7,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 20
+      nodejs: 22
   pre_build:
     commands:
       - npm ci

--- a/buildspec.backendEcs.remove.yml
+++ b/buildspec.backendEcs.remove.yml
@@ -7,7 +7,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 20
+      nodejs: 22
   pre_build:
     commands:
       - npm ci

--- a/buildspec.backendEcs.yml
+++ b/buildspec.backendEcs.yml
@@ -12,7 +12,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 20
+      nodejs: 22
   pre_build:
     commands:
       - npm ci

--- a/buildspec.prod.yml
+++ b/buildspec.prod.yml
@@ -15,7 +15,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 20
+      nodejs: 22
   pre_build:
     commands:
       - npm ci

--- a/buildspec.sls.remove.prod.yml
+++ b/buildspec.sls.remove.prod.yml
@@ -7,7 +7,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 20
+      nodejs: 22
   pre_build:
     commands:
       - npm ci

--- a/buildspec.sls.remove.yml
+++ b/buildspec.sls.remove.yml
@@ -7,7 +7,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 20
+      nodejs: 22
   pre_build:
     commands:
       - npm ci

--- a/buildspec.sls.yml
+++ b/buildspec.sls.yml
@@ -15,7 +15,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 20
+      nodejs: 22
   pre_build:
     commands:
       - npm ci

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,7 +15,7 @@ env:
 phases:
   install:
     runtime-versions:
-      nodejs: 20
+      nodejs: 22
   pre_build:
     commands:
       - npm ci


### PR DESCRIPTION
This pull request includes updates to multiple build specification files to upgrade the Node.js runtime version from 20 to 22.

Updates to Node.js runtime version:

* [`buildspec.backendEcs.remove.prod.yml`](diffhunk://#diff-1ace39d766078cf91636414891ad26dde157d4a2debf5ab44a893ad3c3597a31L10-R10): Upgraded Node.js runtime version from 20 to 22.
* [`buildspec.backendEcs.remove.yml`](diffhunk://#diff-69996f4ab6fff59262e07ecafff43dbfae59c3d4df2d005cb41b61f81c6eddd0L10-R10): Upgraded Node.js runtime version from 20 to 22.
* [`buildspec.backendEcs.yml`](diffhunk://#diff-f1a1766f3482f30a42d06c744ca3f06471871eff079a79807e00287df8000d27L15-R15): Upgraded Node.js runtime version from 20 to 22.
* [`buildspec.prod.yml`](diffhunk://#diff-95a4779a60c8981757068733208a2aeb744c9097412aa27da62fbd0b6442e8caL18-R18): Upgraded Node.js runtime version from 20 to 22.
* [`buildspec.sls.remove.prod.yml`](diffhunk://#diff-75b1b68d50570a2cd6fc155b43a31355eb9c932596e0f8fda52f840f4afa1e16L10-R10): Upgraded Node.js runtime version from 20 to 22.
* [`buildspec.sls.remove.yml`](diffhunk://#diff-01faba4bef2bc6e821c6a3dd54c2a4b67f49b159c0259cb83f5dbf4c5a781bb9L10-R10): Upgraded Node.js runtime version from 20 to 22.
* [`buildspec.sls.yml`](diffhunk://#diff-9b3c0a6d42b3fee85656200161d28b8831c1f61e486dc95159150bb1fc8d2fc5L18-R18): Upgraded Node.js runtime version from 20 to 22.
* [`buildspec.yml`](diffhunk://#diff-69387ac97f1b775f19989fc28150f89e785406cbff04643a969f5e396573dd5cL18-R18): Upgraded Node.js runtime version from 20 to 22.