### PR TITLE
依存ライブラリをアップデートした

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@aws-amplify/analytics": {
-      "version": "7.0.80",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.80.tgz",
-      "integrity": "sha512-KJ22bNnlW+mIAYl+2nM3ZTXhM6svAHUnT0Oi1yzGAwDO0wGYiIUEtV4Vx+21iOZrS3RDrJSEtdynQzfD0eQpLg==",
+      "version": "7.0.81",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.81.tgz",
+      "integrity": "sha512-X2+gI8ek0wyK+c9Z+6AYSb3SNlXyS7CDPdpLEAEb6w4zVKAUX8CykBxIXZGagMX7rFO6oWOB7Zz7vAfAq9yFlg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.621.0",
@@ -84,13 +84,13 @@
       }
     },
     "node_modules/@aws-amplify/api": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.3.11.tgz",
-      "integrity": "sha512-Osp264EBrrp6Rp87Df+y7ngv33kriOY2LxQU40lccUfk3CpFN2nrMbIPZ3JGH0n265L1CGJw3XjpeCLmO3s8ng==",
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.3.12.tgz",
+      "integrity": "sha512-MBvSn9gtM1w1I8r06Q3ZfXo643mAjgVxxDiQ1IBjotJLOIKv9jckjJqCDO+3Mhpd4PaOQfpVsDB7E/a0FLNDYw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/api-graphql": "4.7.15",
-        "@aws-amplify/api-rest": "4.1.4",
+        "@aws-amplify/api-graphql": "4.7.16",
+        "@aws-amplify/api-rest": "4.1.5",
         "@aws-amplify/data-schema": "^1.7.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.5.0"
@@ -100,13 +100,13 @@
       }
     },
     "node_modules/@aws-amplify/api-graphql": {
-      "version": "4.7.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.7.15.tgz",
-      "integrity": "sha512-6lU3Cw7ExvEHFh2jwEgSIA5ws+KyqahmP00u0++W59Lmcg46Y+TJZ27HUlIZkc/QbOk3/HN9M6YopdRa0LqeCg==",
+      "version": "4.7.16",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.7.16.tgz",
+      "integrity": "sha512-o3nddNJMuTNTRnG58Mt+tlo2nYq7YMeheqnPPPBltZ0kYhMz5hnLKlOkZznf5n6brBtE4hPnBtxtlCKFDFIsRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/api-rest": "4.1.4",
-        "@aws-amplify/core": "6.11.4",
+        "@aws-amplify/api-rest": "4.1.5",
+        "@aws-amplify/core": "6.12.0",
         "@aws-amplify/data-schema": "^1.7.0",
         "@aws-sdk/types": "3.387.0",
         "graphql": "15.8.0",
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@aws-amplify/api-rest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.1.4.tgz",
-      "integrity": "sha512-3ajXDy+7XTZriiFR+vqtsnQ5tf4RskkEMpUp++eT+R+pBvudqlAkqe4lB0ABXB1/r1+kXJqDHWEgaXT3DZQZJQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.1.5.tgz",
+      "integrity": "sha512-rrFCVqD2Zip/4HpByyzShLEPIqJ6I1eUPDYf/QTl+/pqP3x8JBHlkNDVE/UmjjyPLEuDRQkRO/6APXfeMTpPAA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -153,9 +153,9 @@
       }
     },
     "node_modules/@aws-amplify/auth": {
-      "version": "6.12.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.12.4.tgz",
-      "integrity": "sha512-3qi3dKJUdYVDS3nCO2YeIK4Djj0vzDEjv2ZpfraYNVBUGXj4GnL7wSUm7r1VD3SYqnHgzoAIdW/73P5ormEMfw==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.13.0.tgz",
+      "integrity": "sha512-PTzCzvSgjjnbkas1C0DLeBvJl+7FAJ9mLoU25AwghyUi5lODvfqcGN7t5T8eYVpd92ICiolasXxA4wJmyOmO+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
@@ -179,9 +179,9 @@
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.11.4.tgz",
-      "integrity": "sha512-qkLyu3GxmJNH6gk9WwKEkOjQ0uUMyOuYqJgf97M6DV6btfoqBFY0T18wd+JEqjKm8awk4liRObU4b9/FQPuS9w==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.12.0.tgz",
+      "integrity": "sha512-/QyfEmHdYtGI6AETvuYyFZ9ZCFVBin2X1Jbim6BaVd9S2HH5U9AqUrKMSJbSPoswmYfJTWxPFeW7KrBeuUUz7Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
@@ -238,9 +238,9 @@
       "license": "MIT"
     },
     "node_modules/@aws-amplify/data-schema": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-1.20.5.tgz",
-      "integrity": "sha512-tMD0JfLj3SOhghsOrT8I3z3Ho/VfRfuG/johBNa8sweymzozYjHKK5TL2NJwu/xHB1Pbt0PaIshNxfIltHbEEQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/data-schema/-/data-schema-1.21.0.tgz",
+      "integrity": "sha512-3SU6zHrvMVOLUiD574aWcVYPVdZ3sPVwQNTPBg5B3DEOkkZ4bGyuiCCKUQiV7AbdSv/1OcZVnPuRFdv+8CW34A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/data-schema-types": "*",
@@ -313,13 +313,13 @@
       }
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "5.0.82",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.82.tgz",
-      "integrity": "sha512-vdCUcpeTN7Cxuke16pZGQg4/zV0z3zs91AsLTkJ6HiOMnFDrqbWdDo+3FB5Mrw0Z6QnBKTUxeZ00K0vn6rgzlQ==",
+      "version": "5.0.83",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.83.tgz",
+      "integrity": "sha512-4W8rJO7QnWV9Kw2OrhXQ1dRQkbbxYX7zDLYyCOC9GncqfK08l7Dh9/C31GllybPwDKqHNy7mc6CkqlC6AFuujg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/api": "6.3.11",
-        "@aws-amplify/api-graphql": "4.7.15",
+        "@aws-amplify/api": "6.3.12",
+        "@aws-amplify/api-graphql": "4.7.16",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "9.0.6",
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@aws-amplify/notifications": {
-      "version": "2.0.80",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.80.tgz",
-      "integrity": "sha512-6ePdufP1gwb//OvuyD/YsnXUvDRXd1sI3+R+Mu+R34IxL34hS1ovEJcM7aAEodvC9bc0jfcyGVoHLxFaRu2nYw==",
+      "version": "2.0.81",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.81.tgz",
+      "integrity": "sha512-YVScErhCs3AIOFn3431uB0VhjiwoKmmg6DitAkwVcDRKM0mqOtZHamIfuB/fJUwMrrigkAjlNhJoOlrB8hQo5g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.398.0",
@@ -370,9 +370,9 @@
       }
     },
     "node_modules/@aws-amplify/storage": {
-      "version": "6.8.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.8.4.tgz",
-      "integrity": "sha512-aplukG1r4dAnKQmvTwc6zS9Oi3CuljRDbyxqTVKPv3oIqgZguTaWyfL6Ta+2XTj5fK816uLL7Rg15Lq1qvU0Ag==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.9.0.tgz",
+      "integrity": "sha512-GgRosKF19CbIYJltwz30grB4Cp1qOnGzYOl7Cea6zZmEULzNBKDzbdGBjxOc2LBFrd9BP+Tz2bQ9Ov39DsNIeQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.398.0",
@@ -9282,17 +9282,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
-      "integrity": "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.33.0.tgz",
+      "integrity": "sha512-CACyQuqSHt7ma3Ns601xykeBK/rDeZa3w6IS6UtMQbixO5DWy+8TilKkviGDH6jtWCo8FGRKEK5cLLkPvEammQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.32.1",
-        "@typescript-eslint/type-utils": "8.32.1",
-        "@typescript-eslint/utils": "8.32.1",
-        "@typescript-eslint/visitor-keys": "8.32.1",
+        "@typescript-eslint/scope-manager": "8.33.0",
+        "@typescript-eslint/type-utils": "8.33.0",
+        "@typescript-eslint/utils": "8.33.0",
+        "@typescript-eslint/visitor-keys": "8.33.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -9306,22 +9306,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "@typescript-eslint/parser": "^8.33.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
-      "integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.0.tgz",
+      "integrity": "sha512-JaehZvf6m0yqYp34+RVnihBAChkqeH+tqqhS0GuX1qgPpwLvmTPheKEs6OeCK6hVJgXZHJ2vbjnC9j119auStQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.32.1",
-        "@typescript-eslint/types": "8.32.1",
-        "@typescript-eslint/typescript-estree": "8.32.1",
-        "@typescript-eslint/visitor-keys": "8.32.1",
+        "@typescript-eslint/scope-manager": "8.33.0",
+        "@typescript-eslint/types": "8.33.0",
+        "@typescript-eslint/typescript-estree": "8.33.0",
+        "@typescript-eslint/visitor-keys": "8.33.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -9336,15 +9336,16 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
-      "integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.0.tgz",
+      "integrity": "sha512-d1hz0u9l6N+u/gcrk6s6gYdl7/+pp8yHheRTqP6X5hVDKALEaTn8WfGiit7G511yueBEL3OpOEpD+3/MBdoN+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.32.1",
-        "@typescript-eslint/visitor-keys": "8.32.1"
+        "@typescript-eslint/tsconfig-utils": "^8.33.0",
+        "@typescript-eslint/types": "^8.33.0",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9354,15 +9355,50 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz",
-      "integrity": "sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==",
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.0.tgz",
+      "integrity": "sha512-LMi/oqrzpqxyO72ltP+dBSP6V0xiUb4saY7WLtxSfiNEBI8m321LLVFU9/QDJxjDQG9/tjSqKz/E3380TEqSTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.32.1",
-        "@typescript-eslint/utils": "8.32.1",
+        "@typescript-eslint/types": "8.33.0",
+        "@typescript-eslint/visitor-keys": "8.33.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.0.tgz",
+      "integrity": "sha512-sTkETlbqhEoiFmGr1gsdq5HyVbSOF0145SYDJ/EQmXHtKViCaGvnyLqWFFHtEXoS0J1yU8Wyou2UGmgW88fEug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.33.0.tgz",
+      "integrity": "sha512-lScnHNCBqL1QayuSrWeqAL5GmqNdVUQAAMTaCwdYEdWfIrSrOGzyLGRCHXcCixa5NK6i5l0AfSO2oBSjCjf4XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.33.0",
+        "@typescript-eslint/utils": "8.33.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -9379,9 +9415,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
-      "integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.0.tgz",
+      "integrity": "sha512-DKuXOKpM5IDT1FA2g9x9x1Ug81YuKrzf4mYX8FAVSNu5Wo/LELHWQyM1pQaDkI42bX15PWl0vNPt1uGiIFUOpg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9393,14 +9429,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
-      "integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.0.tgz",
+      "integrity": "sha512-vegY4FQoB6jL97Tu/lWRsAiUUp8qJTqzAmENH2k59SJhw0Th1oszb9Idq/FyyONLuNqT1OADJPXfyUNOR8SzAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.32.1",
-        "@typescript-eslint/visitor-keys": "8.32.1",
+        "@typescript-eslint/project-service": "8.33.0",
+        "@typescript-eslint/tsconfig-utils": "8.33.0",
+        "@typescript-eslint/types": "8.33.0",
+        "@typescript-eslint/visitor-keys": "8.33.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -9446,16 +9484,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
-      "integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.0.tgz",
+      "integrity": "sha512-lPFuQaLA9aSNa7D5u2EpRiqdAUhzShwGg/nhpBlc4GR6kcTABttCuyjFs8BcEZ8VWrjCBof/bePhP3Q3fS+Yrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.32.1",
-        "@typescript-eslint/types": "8.32.1",
-        "@typescript-eslint/typescript-estree": "8.32.1"
+        "@typescript-eslint/scope-manager": "8.33.0",
+        "@typescript-eslint/types": "8.33.0",
+        "@typescript-eslint/typescript-estree": "8.33.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9470,13 +9508,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
-      "integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.0.tgz",
+      "integrity": "sha512-7RW7CMYoskiz5OOGAWjJFxgb7c5UNjTG292gYhWeOAcFmYCtVCSqjqSBj5zMhxbXo2JOW95YYrUWJfU0zrpaGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.32.1",
+        "@typescript-eslint/types": "8.33.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -10040,25 +10078,25 @@
       }
     },
     "node_modules/aws-amplify": {
-      "version": "6.14.4",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.14.4.tgz",
-      "integrity": "sha512-V1uRj0zg/pMsu0MWEg1tgUyR4YdO9Qfgo+P+tOtHUa0Id3SCWGnSaPCGQjIhli6kWHKT74vYsRwXdTfbKCA6xg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.15.0.tgz",
+      "integrity": "sha512-7h3wLgGzYWPUfdGIk1vgY+UU2/KoBZs5PZiP5aSsxjQdMb2Q7h8fBQgFcGvKG8kK9jD/UI8Mw8e2K/V7Zfw9jw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/analytics": "7.0.80",
-        "@aws-amplify/api": "6.3.11",
-        "@aws-amplify/auth": "6.12.4",
-        "@aws-amplify/core": "6.11.4",
-        "@aws-amplify/datastore": "5.0.82",
-        "@aws-amplify/notifications": "2.0.80",
-        "@aws-amplify/storage": "6.8.4",
+        "@aws-amplify/analytics": "7.0.81",
+        "@aws-amplify/api": "6.3.12",
+        "@aws-amplify/auth": "6.13.0",
+        "@aws-amplify/core": "6.12.0",
+        "@aws-amplify/datastore": "5.0.83",
+        "@aws-amplify/notifications": "2.0.81",
+        "@aws-amplify/storage": "6.9.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1016.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1016.1.tgz",
-      "integrity": "sha512-248TBiluT8jHUjkpzvWJOHv2fS+An9fiII3eji8H7jwfTu5yMBk7on4B/AVNr9A1GXJk9I32qf9Q0A3rLWRYPQ==",
+      "version": "2.1017.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1017.0.tgz",
+      "integrity": "sha512-KnpU9kOCR1k2tAcpYoqtIdq7UqKVX4ooNrGJq+dXUKRnIwQr66tSe5YEoeQGYxImAHv1LuZAyAAm5DcEPhbjNg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -10072,9 +10110,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.198.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.198.0.tgz",
-      "integrity": "sha512-CyZ+lnRsCsLskzQLPO0EiGl5EVcLluhfa67df3b8/gJfsm+91SHJa75OH+ymdGtUp5Vn/MWUPsujw0EhWMfsIQ==",
+      "version": "2.199.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.199.0.tgz",
+      "integrity": "sha512-hAZHdb7bPHepIGpuyg0jS/F3toY7VRvJDqxo4+C2cYY5zvktGP3lgcC9ukE2ehxYU1Pa9YOAehEDIxrita0Hvw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -12350,9 +12388,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
-      "integrity": "sha512-QAfipLcNCWLVocVbZW8GimKn5p5iiMcgGbRzz8z/P5q7xw+cNEpYqyzFMtIF/ZgF2HLOyy+dYBut+DoYolvqig==",
+      "version": "28.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.12.0.tgz",
+      "integrity": "sha512-J6zmDp8WiQ9tyvYXE+3RFy7/+l4hraWLzmsabYXyehkmmDd36qV4VQFc7XzcsD8C1PTNt646MSx25bO1mdd9Yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13220,13 +13258,13 @@
       }
     },
     "node_modules/gbraver-burst-core": {
-      "version": "1.37.1",
-      "resolved": "https://registry.npmjs.org/gbraver-burst-core/-/gbraver-burst-core-1.37.1.tgz",
-      "integrity": "sha512-XToM1yzE7ztBSt4ES1I+XDv71H/7bJv4mhk2rBttTBLGwEVV4D9X105ZLJLdlmDOnYMQe25yeeZQMYriTSeATw==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/gbraver-burst-core/-/gbraver-burst-core-1.38.0.tgz",
+      "integrity": "sha512-Qdj9NU8iMCECRRJ3MyaV05ZcKhugnW9tHIqsaXoKJ3cpG0Pt6seWW5bBnlxE50DGGx1yK+ci8oP8bksxKwn8ww==",
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.30.1",
-        "zod": "^3.25.30"
+        "zod": "^3.25.32"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -18017,9 +18055,9 @@
       }
     },
     "node_modules/serverless": {
-      "version": "4.14.4",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-4.14.4.tgz",
-      "integrity": "sha512-7vsUg6pxBVUZamk4S55IG8Z3Lj+0hE+T4ji+GLjF3knxYcrHK7eIJiLmzui4AQsnoiDuyOiRgY5OogreL8vLPA==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-4.15.1.tgz",
+      "integrity": "sha512-GNb4v+bg/U7DxjgIq8P/aVa7SlU31KFaplgpvzQzr3/GV19xb43LKjorgN0H5CFMGz44ormiHm3/VVjzhxuB5w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -19379,15 +19417,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.32.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.1.tgz",
-      "integrity": "sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.33.0.tgz",
+      "integrity": "sha512-5YmNhF24ylCsvdNW2oJwMzTbaeO4bg90KeGtMjUw0AGtHksgEPLRTUil+coHwCfiu4QjVJFnjp94DmU6zV7DhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.32.1",
-        "@typescript-eslint/parser": "8.32.1",
-        "@typescript-eslint/utils": "8.32.1"
+        "@typescript-eslint/eslint-plugin": "8.33.0",
+        "@typescript-eslint/parser": "8.33.0",
+        "@typescript-eslint/utils": "8.33.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20244,9 +20282,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.30",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.30.tgz",
-      "integrity": "sha512-VolhdEtu6TJr/fzGuHA/SZ5ixvXqA6ADOG9VRcQ3rdOKmF5hkmcJbyaQjUH5BgmpA9gej++zYRX7zjSmdReIwA==",
+      "version": "3.25.39",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.39.tgz",
+      "integrity": "sha512-yrva2T2x4R+FMFTPBVD/YPS7ct8njqjnV93zNx/MlwqLAxcnxwRGbXWyWF63/nErl3rdRd8KARObon7BiWzabQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -20256,7 +20294,7 @@
       "name": "@gbraver-burst-network/aws-vpc",
       "version": "1.16.25",
       "dependencies": {
-        "aws-cdk-lib": "^2.198.0",
+        "aws-cdk-lib": "^2.199.0",
         "constructs": "^10.4.2",
         "dotenv": "^16.5.0",
         "source-map-support": "^0.5.21"
@@ -20266,8 +20304,8 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
-        "@types/node": "22.15.21",
-        "aws-cdk": "2.1016.1",
+        "@types/node": "22.15.26",
+        "aws-cdk": "2.1017.0",
         "dependency-cruiser": "^16.10.2",
         "eslint": "^9.27.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -20276,13 +20314,13 @@
         "prettier": "3.5.3",
         "ts-jest": "^29.3.4",
         "ts-node": "^10.9.2",
-        "typescript-eslint": "^8.32.1"
+        "typescript-eslint": "^8.33.0"
       }
     },
     "packages/aws-vpc/node_modules/@types/node": {
-      "version": "22.15.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
-      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
+      "version": "22.15.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.26.tgz",
+      "integrity": "sha512-lgISkNrqdQ5DAzjBhnDNGKDuXDNo7/1V4FhNzsKREhWLZTOELQAptuAnJMzHtUl1qyEBBy9lNBKQ9WjyiSloTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20301,12 +20339,12 @@
         "@aws-sdk/signature-v4-crt": "^3.816.0",
         "aws-jwt-verify": "^5.1.0",
         "dotenv": "^16.5.0",
-        "gbraver-burst-core": "^1.37.1",
+        "gbraver-burst-core": "^1.38.0",
         "nanoid": "^5.1.5",
         "ramda": "^0.30.1",
         "rimraf": "^6.0.1",
         "uuid": "^11.1.0",
-        "zod": "^3.25.30"
+        "zod": "^3.25.39"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
@@ -20314,15 +20352,15 @@
         "@types/uuid": "^10.0.0",
         "dependency-cruiser": "^16.10.2",
         "eslint": "^9.27.0",
-        "eslint-plugin-jest": "^28.11.0",
+        "eslint-plugin-jest": "^28.12.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "jest": "^29.7.0",
         "npm-run-all": "^4.1.5",
         "prettier": "3.5.3",
-        "serverless": "^4.14.4",
+        "serverless": "^4.15.1",
         "ts-jest": "^29.3.4",
         "ts-loader": "^9.5.2",
-        "typescript-eslint": "^8.32.1",
+        "typescript-eslint": "^8.33.0",
         "webpack": "^5.99.9",
         "webpack-cli": "^6.0.1"
       }
@@ -20439,7 +20477,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/ramda": "^0.30.2",
-        "aws-cdk-lib": "^2.198.0",
+        "aws-cdk-lib": "^2.199.0",
         "constructs": "^10.4.2",
         "dotenv": "^16.5.0",
         "ramda": "^0.30.1",
@@ -20450,9 +20488,9 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
-        "@types/node": "22.15.21",
+        "@types/node": "22.15.26",
         "@types/uuid": "^10.0.0",
-        "aws-cdk": "2.1016.1",
+        "aws-cdk": "2.1017.0",
         "dependency-cruiser": "^16.10.2",
         "eslint": "^9.27.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -20461,13 +20499,13 @@
         "prettier": "3.5.3",
         "ts-jest": "^29.3.4",
         "ts-node": "^10.9.2",
-        "typescript-eslint": "^8.32.1"
+        "typescript-eslint": "^8.33.0"
       }
     },
     "packages/backend-ecs/node_modules/@types/node": {
-      "version": "22.15.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
-      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
+      "version": "22.15.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.26.tgz",
+      "integrity": "sha512-lgISkNrqdQ5DAzjBhnDNGKDuXDNo7/1V4FhNzsKREhWLZTOELQAptuAnJMzHtUl1qyEBBy9lNBKQ9WjyiSloTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20479,23 +20517,23 @@
       "version": "1.16.25",
       "license": "MIT",
       "dependencies": {
-        "aws-amplify": "^6.14.4",
-        "gbraver-burst-core": "^1.37.1",
+        "aws-amplify": "^6.15.0",
+        "gbraver-burst-core": "^1.38.0",
         "rxjs": "^7.8.2",
-        "zod": "^3.25.30"
+        "zod": "^3.25.39"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "dependency-cruiser": "^16.10.2",
         "eslint": "^9.27.0",
-        "eslint-plugin-jest": "^28.11.0",
+        "eslint-plugin-jest": "^28.12.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "jest": "^29.7.0",
         "npm-run-all": "^4.1.5",
         "prettier": "3.5.3",
         "rimraf": "^6.0.1",
         "ts-jest": "^29.3.4",
-        "typescript-eslint": "^8.32.1",
+        "typescript-eslint": "^8.33.0",
         "webpack": "^5.99.9",
         "webpack-cli": "^6.0.1"
       }
@@ -20609,7 +20647,7 @@
       "dependencies": {
         "@gbraver-burst-network/browser-sdk": "*",
         "dotenv": "^16.5.0",
-        "gbraver-burst-core": "^1.37.1"
+        "gbraver-burst-core": "^1.38.0"
       },
       "devDependencies": {
         "dependency-cruiser": "^16.10.2",
@@ -20621,7 +20659,7 @@
         "prettier": "3.5.3",
         "rimraf": "^6.0.1",
         "ts-loader": "^9.5.2",
-        "typescript-eslint": "^8.32.1",
+        "typescript-eslint": "^8.33.0",
         "webpack": "^5.99.9",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20292,7 +20292,7 @@
     },
     "packages/aws-vpc": {
       "name": "@gbraver-burst-network/aws-vpc",
-      "version": "1.16.25",
+      "version": "1.16.26",
       "dependencies": {
         "aws-cdk-lib": "^2.199.0",
         "constructs": "^10.4.2",
@@ -20329,7 +20329,7 @@
     },
     "packages/backend-app": {
       "name": "@gbraver-burst-network/backend-app",
-      "version": "1.16.25",
+      "version": "1.16.26",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.817.0",
@@ -20473,7 +20473,7 @@
     },
     "packages/backend-ecs": {
       "name": "@gbraver-burst-network/backend-ecs",
-      "version": "1.16.25",
+      "version": "1.16.26",
       "license": "MIT",
       "dependencies": {
         "@types/ramda": "^0.30.2",
@@ -20514,7 +20514,7 @@
     },
     "packages/browser-sdk": {
       "name": "@gbraver-burst-network/browser-sdk",
-      "version": "1.16.25",
+      "version": "1.16.26",
       "license": "MIT",
       "dependencies": {
         "aws-amplify": "^6.15.0",
@@ -20642,7 +20642,7 @@
     },
     "packages/serverless-stub": {
       "name": "@gbraver-burst-network/serverless-stub",
-      "version": "1.16.25",
+      "version": "1.16.26",
       "license": "MIT",
       "dependencies": {
         "@gbraver-burst-network/browser-sdk": "*",

--- a/packages/aws-vpc/CHANGELOG.md
+++ b/packages/aws-vpc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/aws-vpc
 
+## 1.16.26
+
+### Patch Changes
+
+- 依存ライブラリをアップデート
+
 ## 1.16.25
 
 ### Patch Changes

--- a/packages/aws-vpc/package.json
+++ b/packages/aws-vpc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/aws-vpc",
   "description": "gbraver burst backend vpc.",
-  "version": "1.16.25",
+  "version": "1.16.26",
   "bin": {
     "aws-vpc": "bin/aws-vpc.js"
   },

--- a/packages/aws-vpc/package.json
+++ b/packages/aws-vpc/package.json
@@ -6,15 +6,15 @@
     "aws-vpc": "bin/aws-vpc.js"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.198.0",
+    "aws-cdk-lib": "^2.199.0",
     "constructs": "^10.4.2",
     "dotenv": "^16.5.0",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "22.15.21",
-    "aws-cdk": "2.1016.1",
+    "@types/node": "22.15.26",
+    "aws-cdk": "2.1017.0",
     "dependency-cruiser": "^16.10.2",
     "eslint": "^9.27.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -23,7 +23,7 @@
     "prettier": "3.5.3",
     "ts-jest": "^29.3.4",
     "ts-node": "^10.9.2",
-    "typescript-eslint": "^8.32.1"
+    "typescript-eslint": "^8.33.0"
   },
   "licens": "MIT",
   "private": true,

--- a/packages/backend-app/CHANGELOG.md
+++ b/packages/backend-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/backend-app
 
+## 1.16.26
+
+### Patch Changes
+
+- 依存ライブラリをアップデート
+
 ## 1.16.25
 
 ### Patch Changes

--- a/packages/backend-app/package.json
+++ b/packages/backend-app/package.json
@@ -11,12 +11,12 @@
     "@aws-sdk/signature-v4-crt": "^3.816.0",
     "aws-jwt-verify": "^5.1.0",
     "dotenv": "^16.5.0",
-    "gbraver-burst-core": "^1.37.1",
+    "gbraver-burst-core": "^1.38.0",
     "nanoid": "^5.1.5",
     "ramda": "^0.30.1",
     "rimraf": "^6.0.1",
     "uuid": "^11.1.0",
-    "zod": "^3.25.30"
+    "zod": "^3.25.39"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
@@ -24,15 +24,15 @@
     "@types/uuid": "^10.0.0",
     "dependency-cruiser": "^16.10.2",
     "eslint": "^9.27.0",
-    "eslint-plugin-jest": "^28.11.0",
+    "eslint-plugin-jest": "^28.12.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "jest": "^29.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "3.5.3",
-    "serverless": "^4.14.4",
+    "serverless": "^4.15.1",
     "ts-jest": "^29.3.4",
     "ts-loader": "^9.5.2",
-    "typescript-eslint": "^8.32.1",
+    "typescript-eslint": "^8.33.0",
     "webpack": "^5.99.9",
     "webpack-cli": "^6.0.1"
   },

--- a/packages/backend-app/package.json
+++ b/packages/backend-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/backend-app",
   "description": "gbraver burst backend app",
-  "version": "1.16.25",
+  "version": "1.16.26",
   "author": "Y.Takeuchi",
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.817.0",

--- a/packages/backend-app/test/src/core/__snapshots__/progress-battle.test.ts.snap
+++ b/packages/backend-app/test/src/core/__snapshots__/progress-battle.test.ts.snap
@@ -800,6 +800,7 @@ exports[`バトル進行の結果、バトル継続となる 1`] = `
         "activePlayerId": "defender-player",
         "effect": {
           "name": "TurnChange",
+          "reason": "Normal",
           "recoverBattery": 3,
         },
         "players": [
@@ -1290,6 +1291,7 @@ exports[`バトル進行の結果、バトル継続となる 1`] = `
       "activePlayerId": "defender-player",
       "effect": {
         "name": "TurnChange",
+        "reason": "Normal",
         "recoverBattery": 3,
       },
       "players": [

--- a/packages/backend-ecs/CHANGELOG.md
+++ b/packages/backend-ecs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/backend-ecs
 
+## 1.16.26
+
+### Patch Changes
+
+- 依存ライブラリをアップデート
+
 ## 1.16.25
 
 ### Patch Changes

--- a/packages/backend-ecs/package.json
+++ b/packages/backend-ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/backend-ecs",
   "description": "create backend ecs.",
-  "version": "1.16.25",
+  "version": "1.16.26",
   "bin": {
     "backend-ecs": "bin/backend-ecs.js"
   },

--- a/packages/backend-ecs/package.json
+++ b/packages/backend-ecs/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@types/ramda": "^0.30.2",
-    "aws-cdk-lib": "^2.198.0",
+    "aws-cdk-lib": "^2.199.0",
     "constructs": "^10.4.2",
     "dotenv": "^16.5.0",
     "ramda": "^0.30.1",
@@ -15,9 +15,9 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "22.15.21",
+    "@types/node": "22.15.26",
     "@types/uuid": "^10.0.0",
-    "aws-cdk": "2.1016.1",
+    "aws-cdk": "2.1017.0",
     "dependency-cruiser": "^16.10.2",
     "eslint": "^9.27.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -26,7 +26,7 @@
     "prettier": "3.5.3",
     "ts-jest": "^29.3.4",
     "ts-node": "^10.9.2",
-    "typescript-eslint": "^8.32.1"
+    "typescript-eslint": "^8.33.0"
   },
   "license": "MIT",
   "private": true,

--- a/packages/browser-sdk/CHANGELOG.md
+++ b/packages/browser-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/browser-sdk
 
+## 1.16.26
+
+### Patch Changes
+
+- 依存ライブラリをアップデート
+
 ## 1.16.25
 
 ### Patch Changes

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/browser-sdk",
   "description": "gbraver burst browser sdk",
-  "version": "1.16.25",
+  "version": "1.16.26",
   "author": "Y.Takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-network/issues",

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -8,23 +8,23 @@
     "email": "kaidouji85@gmail.com"
   },
   "dependencies": {
-    "aws-amplify": "^6.14.4",
-    "gbraver-burst-core": "^1.37.1",
+    "aws-amplify": "^6.15.0",
+    "gbraver-burst-core": "^1.38.0",
     "rxjs": "^7.8.2",
-    "zod": "^3.25.30"
+    "zod": "^3.25.39"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "dependency-cruiser": "^16.10.2",
     "eslint": "^9.27.0",
-    "eslint-plugin-jest": "^28.11.0",
+    "eslint-plugin-jest": "^28.12.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "jest": "^29.7.0",
     "npm-run-all": "^4.1.5",
     "prettier": "3.5.3",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.3.4",
-    "typescript-eslint": "^8.32.1",
+    "typescript-eslint": "^8.33.0",
     "webpack": "^5.99.9",
     "webpack-cli": "^6.0.1"
   },

--- a/packages/serverless-stub/CHANGELOG.md
+++ b/packages/serverless-stub/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @gbraver-burst-network/serverless-stub
 
+## 1.16.26
+
+### Patch Changes
+
+- 依存ライブラリをアップデート
+- Updated dependencies
+  - @gbraver-burst-network/browser-sdk@1.16.26
+
 ## 1.16.25
 
 ### Patch Changes

--- a/packages/serverless-stub/package.json
+++ b/packages/serverless-stub/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/serverless-stub",
   "description": "gbraver burst network stub.",
-  "version": "1.16.25",
+  "version": "1.16.26",
   "author": "Y.Takeuchi",
   "dependencies": {
     "@gbraver-burst-network/browser-sdk": "*",

--- a/packages/serverless-stub/package.json
+++ b/packages/serverless-stub/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@gbraver-burst-network/browser-sdk": "*",
     "dotenv": "^16.5.0",
-    "gbraver-burst-core": "^1.37.1"
+    "gbraver-burst-core": "^1.38.0"
   },
   "devDependencies": {
     "dependency-cruiser": "^16.10.2",
@@ -18,7 +18,7 @@
     "prettier": "3.5.3",
     "rimraf": "^6.0.1",
     "ts-loader": "^9.5.2",
-    "typescript-eslint": "^8.32.1",
+    "typescript-eslint": "^8.33.0",
     "webpack": "^5.99.9",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.1"


### PR DESCRIPTION
This pull request updates the version numbers and dependencies across multiple packages in the project to ensure compatibility and incorporate the latest changes. The updates include both runtime and development dependencies, as well as synchronized version bumps for all affected packages.

### Dependency Updates

* Updated `aws-cdk-lib` to `^2.199.0` and `aws-cdk` to `2.1017.0` in `@gbraver-burst-network/aws-vpc` and `@gbraver-burst-network/backend-ecs`. (`[[1]](diffhunk://#diff-1e1d61e86cebb7496b3ea3d5b51cbbc6a17797a048b7bb331f6105237468e218L4-R17)`, `[[2]](diffhunk://#diff-d09faa1ceef5d3684323489669d6f26951645a3ea38c71c77d44fa7538db8ba9L4-R20)`)
* Updated `gbraver-burst-core` to `^1.38.0` and `zod` to `^3.25.39` in `@gbraver-burst-network/backend-app`, `@gbraver-burst-network/browser-sdk`, and `@gbraver-burst-network/serverless-stub`. (`[[1]](diffhunk://#diff-e8863e6291315635ed6033580947eab3fd63b3762e026775bedd8df074cb941cL14-R35)`, `[[2]](diffhunk://#diff-475fbf96532457ba4b9457941110adacea0f854ef45e19448218936a2086e9dbL4-R27)`, `[[3]](diffhunk://#diff-5f72d91b4238ef7c141e9fe955fcc260b841ecf4c2d33f9f55ee8d36b4ac3f42L4-R9)`)
* Updated `aws-amplify` to `^6.15.0` in `@gbraver-burst-network/browser-sdk`. (`[packages/browser-sdk/package.jsonL4-R27](diffhunk://#diff-475fbf96532457ba4b9457941110adacea0f854ef45e19448218936a2086e9dbL4-R27)`)

### Development Dependency Updates

* Updated `@types/node` to `22.15.26` and `typescript-eslint` to `^8.33.0` across all packages. (`[[1]](diffhunk://#diff-1e1d61e86cebb7496b3ea3d5b51cbbc6a17797a048b7bb331f6105237468e218L26-R26)`, `[[2]](diffhunk://#diff-d09faa1ceef5d3684323489669d6f26951645a3ea38c71c77d44fa7538db8ba9L29-R29)`, `[[3]](diffhunk://#diff-5f72d91b4238ef7c141e9fe955fcc260b841ecf4c2d33f9f55ee8d36b4ac3f42L21-R21)`)
* Updated `eslint-plugin-jest` to `^28.12.0` in `@gbraver-burst-network/backend-app` and `@gbraver-burst-network/browser-sdk`. (`[[1]](diffhunk://#diff-e8863e6291315635ed6033580947eab3fd63b3762e026775bedd8df074cb941cL14-R35)`, `[[2]](diffhunk://#diff-475fbf96532457ba4b9457941110adacea0f854ef45e19448218936a2086e9dbL4-R27)`)
* Updated `serverless` to `^4.15.1` in `@gbraver-burst-network/backend-app`. (`[packages/backend-app/package.jsonL14-R35](diffhunk://#diff-e8863e6291315635ed6033580947eab3fd63b3762e026775bedd8df074cb941cL14-R35)`)

### Version Synchronization

* Synchronized package versions to `1.16.26` across all packages (`aws-vpc`, `backend-app`, `backend-ecs`, `browser-sdk`, and `serverless-stub`) to maintain consistency. (`[[1]](diffhunk://#diff-1e1d61e86cebb7496b3ea3d5b51cbbc6a17797a048b7bb331f6105237468e218L4-R17)`, `[[2]](diffhunk://#diff-e8863e6291315635ed6033580947eab3fd63b3762e026775bedd8df074cb941cL4-R4)`, `[[3]](diffhunk://#diff-d09faa1ceef5d3684323489669d6f26951645a3ea38c71c77d44fa7538db8ba9L4-R20)`, `[[4]](diffhunk://#diff-475fbf96532457ba4b9457941110adacea0f854ef45e19448218936a2086e9dbL4-R27)`, `[[5]](diffhunk://#diff-5f72d91b4238ef7c141e9fe955fcc260b841ecf4c2d33f9f55ee8d36b4ac3f42L4-R9)`)

### Changelog Updates

* Added entries in the `CHANGELOG.md` files for all packages to document the dependency updates and version changes. (`[[1]](diffhunk://#diff-a4ee225b383c2e39cb1447ea38ce20f8462216a3de29f8b0ce415c8db3a4685dR3-R8)`, `[[2]](diffhunk://#diff-a70fd3fea3782a67f2de830f3f3000e07ef1eb828347ecd1cb589b79c547779fR3-R8)`, `[[3]](diffhunk://#diff-d08b7108571d480cefcf3071e83fc09f4d767089a32b0cfb4a3476ab91e076ecR3-R8)`, `[[4]](diffhunk://#diff-fd71b57137241809d8a8c569cb843ce8a29d5ee2705306974c4bb249e8eae4d7R3-R8)`, `[[5]](diffhunk://#diff-f012c4416a49f6ab20d64a45dbc6b89868b6d5581dafa1dc0b394e0b21399b08R3-R10)`)