### PR TITLE
fix: オフラインバックエンドアプリのポートとCORS設定を更新

### DIFF
--- a/packages/offline-backend-app/.env.template
+++ b/packages/offline-backend-app/.env.template
@@ -1,5 +1,5 @@
 # オフラインバックエンドアプリケーション設定
-PORT=3000
+PORT=8888
 
 # CORS設定
-CORS_ORIGIN=http://localhost:8080
+CORS_ORIGIN=http://<展示用マシンのローカルIP>:3000


### PR DESCRIPTION
This pull request updates environment configuration settings for the offline backend application, primarily to support deployment on a demonstration machine.

Configuration updates:

* Changed the `PORT` value in `.env.template` from `3000` to `8888` to match the new deployment requirements.
* Modified the `CORS_ORIGIN` value to reference the local IP address of the demonstration machine instead of `localhost`, ensuring proper cross-origin access from the frontend.