### PR TITLE
サーバーレスアプリにX-Rayを導入した

### DIFF
--- a/packages/backend-app/serverless.yml
+++ b/packages/backend-app/serverless.yml
@@ -15,6 +15,8 @@ provider:
     websocket: true
   runtime: nodejs22.x
   region: ap-northeast-1
+  tracing:
+    lambda: true
   httpApi:
     name: ${self:service}__${sls:stage}__rest-api
     cors:
@@ -42,6 +44,11 @@ provider:
   iam:
     role:
       statements:
+        - Effect: Allow
+          Action:
+            - "xray:PutTraceSegments"
+            - "xray:PutTelemetryRecords"
+          Resource: "*"
         - Effect: Allow
           Action:
             - "dynamodb:PutItem"


### PR DESCRIPTION
This pull request introduces AWS X-Ray tracing support to the backend application by updating the Serverless configuration. The main changes enable tracing for Lambda functions and grant the necessary IAM permissions for X-Ray operations.

**Tracing configuration:**

* Enabled AWS X-Ray tracing for all Lambda functions by adding the `tracing.lambda: true` property to the `provider` section of `serverless.yml`.

**IAM permissions:**

* Added IAM role statements to allow the actions `xray:PutTraceSegments` and `xray:PutTelemetryRecords` on all resources, enabling Lambda functions to send trace data to AWS X-Ray.