### PR TITLE
API Gatewayのトレース設定を有効化

### DIFF
--- a/packages/backend-app/serverless.yml
+++ b/packages/backend-app/serverless.yml
@@ -16,6 +16,7 @@ provider:
   runtime: nodejs22.x
   region: ap-northeast-1
   tracing:
+    apiGateway: true
     lambda: true
   websocketsApiName: ${self:service}__${sls:stage}__ws-api
   websocketsApiRouteSelectionExpression: $request.body.action


### PR DESCRIPTION
This pull request makes a small configuration update to enable API Gateway tracing in the serverless deployment settings. This will help with monitoring and debugging API requests.

* Serverless configuration: Enabled `apiGateway` tracing in the `provider.tracing` section of `serverless.yml`.