### PR TITLE
npm publishのエラーを修正

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,6 +9,9 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  # serverless frameworkのビルドを通すためのダミー値
+  # 同フレームワークを用いているパッケージはnpm publishの対象ではないため、ダミーでも問題ない
+  WS_API_DOMAIN_NAME: "dummy-value.not-used.com"
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a minor update to the npm publish workflow configuration. A dummy value for `WS_API_DOMAIN_NAME` has been added to the environment variables to allow the Serverless Framework build to proceed. This is safe because packages using this framework are not published via npm.

- Workflow configuration:
  * Added `WS_API_DOMAIN_NAME` with a dummy value to `.github/workflows/npm-publish.yml` to ensure Serverless Framework builds succeed, noting that this value is not used for npm-published packages.