### PR TITLE
依存パッケージを更新し、バージョンを1.19.2にアップデートした

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23144,7 +23144,7 @@
     },
     "packages/aws-vpc": {
       "name": "@gbraver-burst-network/aws-vpc",
-      "version": "1.19.1",
+      "version": "1.19.2",
       "license": "MIT",
       "dependencies": {
         "aws-cdk-lib": "^2.233.0",
@@ -23172,7 +23172,7 @@
     },
     "packages/backend-app": {
       "name": "@gbraver-burst-network/backend-app",
-      "version": "1.19.1",
+      "version": "1.19.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.958.0",
@@ -23301,7 +23301,7 @@
     },
     "packages/backend-ecs": {
       "name": "@gbraver-burst-network/backend-ecs",
-      "version": "1.19.1",
+      "version": "1.19.2",
       "license": "MIT",
       "dependencies": {
         "@types/ramda": "^0.31.1",
@@ -23331,7 +23331,7 @@
     },
     "packages/browser-sdk": {
       "name": "@gbraver-burst-network/browser-sdk",
-      "version": "1.19.1",
+      "version": "1.19.2",
       "license": "MIT",
       "dependencies": {
         "aws-amplify": "^6.15.9",
@@ -23355,8 +23355,8 @@
         "zod": "^4.3.4"
       },
       "peerDependencies": {
-        "gbraver-burst-core": "^1.42.1",
-        "zod": "^4.2.1"
+        "gbraver-burst-core": "^1.43.1",
+        "zod": "^4.3.4"
       }
     },
     "packages/browser-sdk/node_modules/glob": {
@@ -23442,7 +23442,7 @@
     },
     "packages/offline-backend-app": {
       "name": "@gbraver-burst-network/offline-backend-app",
-      "version": "1.19.1",
+      "version": "1.19.2",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
@@ -23744,7 +23744,7 @@
     },
     "packages/offline-browser-sdk": {
       "name": "@gbraver-burst-network/offline-browser-sdk",
-      "version": "1.19.1",
+      "version": "1.19.2",
       "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.2",
@@ -23763,8 +23763,8 @@
         "zod": "^4.3.4"
       },
       "peerDependencies": {
-        "gbraver-burst-core": "^1.42.1",
-        "zod": "^4.2.1"
+        "gbraver-burst-core": "^1.43.1",
+        "zod": "^4.3.4"
       }
     },
     "packages/offline-browser-sdk/node_modules/glob": {
@@ -23850,7 +23850,7 @@
     },
     "packages/offline-stub": {
       "name": "@gbraver-burst-network/offline-stub",
-      "version": "1.19.1",
+      "version": "1.19.2",
       "license": "MIT",
       "dependencies": {
         "@gbraver-burst-network/offline-browser-sdk": "*",
@@ -23954,7 +23954,7 @@
     },
     "packages/serverless-stub": {
       "name": "@gbraver-burst-network/serverless-stub",
-      "version": "1.19.1",
+      "version": "1.19.2",
       "license": "MIT",
       "dependencies": {
         "@gbraver-burst-network/browser-sdk": "*",

--- a/packages/aws-vpc/CHANGELOG.md
+++ b/packages/aws-vpc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/aws-vpc
 
+## 1.19.2
+
+### Patch Changes
+
+- 依存パッケージを更新した
+
 ## 1.19.1
 
 ### Patch Changes

--- a/packages/aws-vpc/package.json
+++ b/packages/aws-vpc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/aws-vpc",
   "description": "gbraver burst backend vpc.",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "bin": {
     "aws-vpc": "bin/aws-vpc.js"
   },

--- a/packages/backend-app/CHANGELOG.md
+++ b/packages/backend-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/backend-app
 
+## 1.19.2
+
+### Patch Changes
+
+- 依存パッケージを更新した
+
 ## 1.19.1
 
 ### Patch Changes

--- a/packages/backend-app/package.json
+++ b/packages/backend-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/backend-app",
   "description": "gbraver burst backend app",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "author": "Y.Takeuchi",
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.958.0",

--- a/packages/backend-ecs/CHANGELOG.md
+++ b/packages/backend-ecs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/backend-ecs
 
+## 1.19.2
+
+### Patch Changes
+
+- 依存パッケージを更新した
+
 ## 1.19.1
 
 ### Patch Changes

--- a/packages/backend-ecs/package.json
+++ b/packages/backend-ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/backend-ecs",
   "description": "create backend ecs.",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "bin": {
     "backend-ecs": "bin/backend-ecs.js"
   },

--- a/packages/browser-sdk/CHANGELOG.md
+++ b/packages/browser-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/browser-sdk
 
+## 1.19.2
+
+### Patch Changes
+
+- 依存パッケージを更新した
+
 ## 1.19.1
 
 ### Patch Changes

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/browser-sdk",
   "description": "gbraver burst browser sdk",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "author": "Y.Takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-network/issues",

--- a/packages/offline-backend-app/CHANGELOG.md
+++ b/packages/offline-backend-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/offline-backend-app
 
+## 1.19.2
+
+### Patch Changes
+
+- 依存パッケージを更新した
+
 ## 1.19.1
 
 ### Patch Changes

--- a/packages/offline-backend-app/package.json
+++ b/packages/offline-backend-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/offline-backend-app",
   "description": "gbraver burst offline backend app",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "author": "Y.Takeuchi",
   "dependencies": {
     "cors": "^2.8.5",

--- a/packages/offline-browser-sdk/CHANGELOG.md
+++ b/packages/offline-browser-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/offline-browser-sdk
 
+## 1.19.2
+
+### Patch Changes
+
+- 依存パッケージを更新した
+
 ## 1.19.1
 
 ### Patch Changes

--- a/packages/offline-browser-sdk/package.json
+++ b/packages/offline-browser-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/offline-browser-sdk",
   "description": "gbraver burst offline browser sdk",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "author": "Y.Takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-network/issues",

--- a/packages/offline-stub/CHANGELOG.md
+++ b/packages/offline-stub/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @gbraver-burst-network/offline-stub
 
+## 1.19.2
+
+### Patch Changes
+
+- 依存パッケージを更新した
+- Updated dependencies
+  - @gbraver-burst-network/offline-browser-sdk@1.19.2
+
 ## 1.19.1
 
 ### Patch Changes

--- a/packages/offline-stub/package.json
+++ b/packages/offline-stub/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/offline-stub",
   "description": "gbraver burst offline browser sdk",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "author": "Y.Takeuchi",
   "dependencies": {
     "@gbraver-burst-network/offline-browser-sdk": "*",

--- a/packages/serverless-stub/CHANGELOG.md
+++ b/packages/serverless-stub/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @gbraver-burst-network/serverless-stub
 
+## 1.19.2
+
+### Patch Changes
+
+- 依存パッケージを更新した
+- Updated dependencies
+  - @gbraver-burst-network/browser-sdk@1.19.2
+
 ## 1.19.1
 
 ### Patch Changes

--- a/packages/serverless-stub/package.json
+++ b/packages/serverless-stub/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/serverless-stub",
   "description": "gbraver burst network stub.",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "author": "Y.Takeuchi",
   "dependencies": {
     "@gbraver-burst-network/browser-sdk": "*",


### PR DESCRIPTION
This pull request updates multiple packages in the monorepo to version 1.19.2, primarily to update dependencies and ensure consistency across the project. All affected packages have their `package.json` and `CHANGELOG.md` files updated accordingly.

Dependency updates:

* Updated dependencies in the following packages to the latest versions: `@gbraver-burst-network/aws-vpc`, `@gbraver-burst-network/backend-app`, `@gbraver-burst-network/backend-ecs`, `@gbraver-burst-network/browser-sdk`, `@gbraver-burst-network/offline-backend-app`, `@gbraver-burst-network/offline-browser-sdk`, `@gbraver-burst-network/offline-stub`, and `@gbraver-burst-network/serverless-stub`. [[1]](diffhunk://#diff-a4ee225b383c2e39cb1447ea38ce20f8462216a3de29f8b0ce415c8db3a4685dR3-R8) [[2]](diffhunk://#diff-a70fd3fea3782a67f2de830f3f3000e07ef1eb828347ecd1cb589b79c547779fR3-R8) [[3]](diffhunk://#diff-d08b7108571d480cefcf3071e83fc09f4d767089a32b0cfb4a3476ab91e076ecR3-R8) [[4]](diffhunk://#diff-fd71b57137241809d8a8c569cb843ce8a29d5ee2705306974c4bb249e8eae4d7R3-R8) [[5]](diffhunk://#diff-19e1855e5e873f97f75d0fe89ab1490ffc2a6287bb2e5f6ed84e6f625f27a88dR3-R8) [[6]](diffhunk://#diff-687ab108f6a319d5fc658fecea661d9eed29e5726f18a0a224e1d93de48ebf86R3-R8) [[7]](diffhunk://#diff-3ce41f8f41c0dc599478b204c925dc39c43b3ff3d1f99f85295dd83a57a7640dR3-R10) [[8]](diffhunk://#diff-f012c4416a49f6ab20d64a45dbc6b89868b6d5581dafa1dc0b394e0b21399b08R3-R10)

Version bumps and changelog updates:

* Bumped the version to `1.19.2` in `package.json` and added corresponding changelog entries for all affected packages: `aws-vpc`, `backend-app`, `backend-ecs`, `browser-sdk`, `offline-backend-app`, `offline-browser-sdk`, `offline-stub`, and `serverless-stub`. [[1]](diffhunk://#diff-1e1d61e86cebb7496b3ea3d5b51cbbc6a17797a048b7bb331f6105237468e218L4-R4) [[2]](diffhunk://#diff-e8863e6291315635ed6033580947eab3fd63b3762e026775bedd8df074cb941cL4-R4) [[3]](diffhunk://#diff-d09faa1ceef5d3684323489669d6f26951645a3ea38c71c77d44fa7538db8ba9L4-R4) [[4]](diffhunk://#diff-475fbf96532457ba4b9457941110adacea0f854ef45e19448218936a2086e9dbL4-R4) [[5]](diffhunk://#diff-12ce8a9bf893a21fbf1126ec9626d07e3d7b9f798e5b7bcb28fd85158bc3384fL4-R4) [[6]](diffhunk://#diff-b8829937252f063f9ae974cfb69d5b61f7910ff558c5f6adf945d6d05a7c79d6L4-R4) [[7]](diffhunk://#diff-dafa27d82b8c53e4e3472b49a356cfdc58a6bd5a434718206693f204e522880cL4-R4) [[8]](diffhunk://#diff-5f72d91b4238ef7c141e9fe955fcc260b841ecf4c2d33f9f55ee8d36b4ac3f42L4-R4)

Internal dependency alignment:

* Updated internal dependencies to use the new `1.19.2` versions in `offline-stub` (`@gbraver-burst-network/offline-browser-sdk`) and `serverless-stub` (`@gbraver-burst-network/browser-sdk`). [[1]](diffhunk://#diff-3ce41f8f41c0dc599478b204c925dc39c43b3ff3d1f99f85295dd83a57a7640dR3-R10) [[2]](diffhunk://#diff-f012c4416a49f6ab20d64a45dbc6b89868b6d5581dafa1dc0b394e0b21399b08R3-R10)