### PR TITLE
feat: 1ユーザー1接続の管理を実装

### DIFF
--- a/packages/backend-app/serverless.yml
+++ b/packages/backend-app/serverless.yml
@@ -48,20 +48,20 @@ provider:
             - "dynamodb:BatchWrite*"
           Resource:
             - Fn::GetAtt: [ConnectionsTable, Arn]
+            - Fn::Join:
+                [
+                  "/",
+                  [
+                    "Fn::GetAtt": [ConnectionsTable, Arn],
+                    "index",
+                    "userID",
+                  ],
+                ]
             - Fn::GetAtt: [CasualMatchEntriesTable, Arn]
             - Fn::GetAtt: [BattleCommandsTable, Arn]
             - Fn::GetAtt: [BattlesTable, Arn]
             - Fn::GetAtt: [PrivateMatchRoomsTable, Arn]
             - Fn::GetAtt: [PrivateMatchEntriesTable, Arn]
-            - Fn::Join:
-                [
-                  "/",
-                  [
-                    "Fn::GetAtt": [PrivateMatchRoomsTable, Arn],
-                    "index",
-                    "roomID",
-                  ],
-                ]
         - Effect: Allow
           Action:
             - "execute-api:ManageConnections"
@@ -130,9 +130,18 @@ resources:
         AttributeDefinitions:
           - AttributeName: connectionId
             AttributeType: S
+          - AttributeName: userID
+            AttributeType: S
         KeySchema:
           - AttributeName: connectionId
             KeyType: HASH
+        GlobalSecondaryIndexes:
+          - IndexName: userID
+            KeySchema:
+              - AttributeName: userID
+                KeyType: HASH
+            Projection:
+              ProjectionType: KEYS_ONLY
         BillingMode: PAY_PER_REQUEST
     CasualMatchEntriesTable:
       Type: "AWS::DynamoDB::Table"

--- a/packages/backend-app/serverless.yml
+++ b/packages/backend-app/serverless.yml
@@ -51,11 +51,7 @@ provider:
             - Fn::Join:
                 [
                   "/",
-                  [
-                    "Fn::GetAtt": [ConnectionsTable, Arn],
-                    "index",
-                    "userID",
-                  ],
+                  ["Fn::GetAtt": [ConnectionsTable, Arn], "index", "userID"],
                 ]
             - Fn::GetAtt: [CasualMatchEntriesTable, Arn]
             - Fn::GetAtt: [BattleCommandsTable, Arn]

--- a/packages/backend-app/src/connect.ts
+++ b/packages/backend-app/src/connect.ts
@@ -3,27 +3,34 @@ import { createApiGatewayManagementApi } from "./api-gateway/management";
 import { createDynamoConnections } from "./dynamo-db/create-dynamo-connections";
 import { createDynamoDBDocument } from "./dynamo-db/dynamo-db-document";
 import { extractUserFromWebSocketAuthorizer } from "./lambda/extract-user";
-import type { WebsocketAPIEvent } from "./lambda/websocket-api-event";
-import type { WebsocketAPIResponse } from "./lambda/websocket-api-response";
+import { WebsocketAPIEvent } from "./lambda/websocket-api-event";
+import { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 
+/** AWSリージョン */
 const AWS_REGION = process.env.AWS_REGION ?? "";
+/** サービス名 */
 const SERVICE = process.env.SERVICE ?? "";
+/** ステージ名 */
 const STAGE = process.env.STAGE ?? "";
+/** WebSocket API ID */
 const WEBSOCKET_API_ID = process.env.WEBSOCKET_API_ID ?? "";
 
+/** API Gateway エンドポイント */
 const apiGatewayEndpoint = createAPIGatewayEndpoint(
   WEBSOCKET_API_ID,
   AWS_REGION,
   STAGE,
 );
+/** API Gateway Management API */
 const apiGateway = createApiGatewayManagementApi(apiGatewayEndpoint);
 
+/** DynamoDB ドキュメントクライアント */
 const dynamoDB = createDynamoDBDocument(AWS_REGION);
+/** DynamoDB DAO connections */
 const dynamoConnections = createDynamoConnections(dynamoDB, SERVICE, STAGE);
 
 /**
  * Websocket API $connect エントリポイント
- *
  * @param event イベント
  * @returns レスポンス
  */

--- a/packages/backend-app/src/connect.ts
+++ b/packages/backend-app/src/connect.ts
@@ -42,13 +42,15 @@ export async function connect(
   );
 
   const currentConnectionId = event.requestContext.connectionId;
-  const connections = await dynamoConnections.queryByUserID(user.userID);
+  const connectionIds = await dynamoConnections.queryConnectionIdsByUserID(
+    user.userID,
+  );
   // GSIの結果整合性およびConnectionID再利用などで、
   // 既存コネクションテーブルに同一ユーザIDの別コネクションが存在した場合に備えて、
   // filterで現在のコネクションIDを除外している
-  const oldConnectionIds = connections
-    .map((c) => c.connectionId)
-    .filter((id) => id !== currentConnectionId);
+  const oldConnectionIds = connectionIds.filter(
+    (id) => id !== currentConnectionId,
+  );
   const deletedOldConnectionResults = await Promise.allSettled(
     oldConnectionIds.map((oldConnectionId) =>
       apiGateway.deleteConnection({ ConnectionId: oldConnectionId }),

--- a/packages/backend-app/src/connect.ts
+++ b/packages/backend-app/src/connect.ts
@@ -50,6 +50,7 @@ export async function connect(
   const oldConnectionIds = connectionIds.filter(
     (id) => id !== currentConnectionId,
   );
+  // ここでは旧接続の切断のみ行い、終了処理と通知は$disconnectで行う
   const deletedOldConnectionResults = await Promise.allSettled(
     oldConnectionIds.map((oldConnectionId) =>
       apiGateway.deleteConnection({ ConnectionId: oldConnectionId }),

--- a/packages/backend-app/src/connect.ts
+++ b/packages/backend-app/src/connect.ts
@@ -40,7 +40,6 @@ export async function connect(
   const user = extractUserFromWebSocketAuthorizer(
     event.requestContext.authorizer,
   );
-
   const currentConnectionId = event.requestContext.connectionId;
   const connectionIds = await dynamoConnections.queryConnectionIdsByUserID(
     user.userID,
@@ -65,9 +64,7 @@ export async function connect(
   await dynamoConnections.put({
     connectionId: currentConnectionId,
     userID: user.userID,
-    state: {
-      type: "None",
-    },
+    state: { type: "None" },
   });
   return {
     statusCode: 200,

--- a/packages/backend-app/src/dynamo-db/dynamo-connections.ts
+++ b/packages/backend-app/src/dynamo-db/dynamo-connections.ts
@@ -1,4 +1,5 @@
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
+import { z } from "zod";
 
 import { Connection, ConnectionSchema } from "../core/connection";
 
@@ -58,11 +59,11 @@ export class DynamoConnections {
   }
 
   /**
-   * userID で GSI をクエリして該当接続を取得する
+   * userID で GSI をクエリして該当connectionId 配列を取得する
    * @param userID ユーザID
-   * @returns 該当する Connection 配列（未存在は空配列）
+   * @returns 該当するconnectionId配列（未存在は空配列）
    */
-  async queryByUserID(userID: string): Promise<DynamoConnection[]> {
+  async queryConnectionIdsByUserID(userID: string): Promise<string[]> {
     const result = await this.#dynamoDB.query({
       TableName: this.#tableName,
       IndexName: USER_ID_INDEX,
@@ -70,7 +71,7 @@ export class DynamoConnections {
       ExpressionAttributeValues: { ":uid": userID },
     });
     const items = result.Items ?? [];
-    return items.map((it) => DynamoConnectionSchema.parse(it));
+    return items.map((it) => z.string().parse(it.connectionId));
   }
 
   /**

--- a/packages/backend-app/src/dynamo-db/dynamo-connections.ts
+++ b/packages/backend-app/src/dynamo-db/dynamo-connections.ts
@@ -2,6 +2,9 @@ import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
 
 import { Connection, ConnectionSchema } from "../core/connection";
 
+/** userID の GSI 名 */
+const USER_ID_INDEX = "userID";
+
 /**
  * DynamoDB スキーマ connections
  * パーティションキー connectionId
@@ -52,6 +55,22 @@ export class DynamoConnections {
       TableName: this.#tableName,
       Item: connection,
     });
+  }
+
+  /**
+   * userID で GSI をクエリして該当接続を取得する
+   * @param userID ユーザID
+   * @returns 該当する Connection 配列（未存在は空配列）
+   */
+  async queryByUserID(userID: string): Promise<DynamoConnection[]> {
+    const result = await this.#dynamoDB.query({
+      TableName: this.#tableName,
+      IndexName: USER_ID_INDEX,
+      KeyConditionExpression: "userID = :uid",
+      ExpressionAttributeValues: { ":uid": userID },
+    });
+    const items = result.Items ?? [];
+    return items.map((it) => DynamoConnectionSchema.parse(it));
   }
 
   /**

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -16,6 +16,7 @@ export type WebsocketResponse =
   | CreatedPrivateMatchRoom
   | CouldNotPrivateMatchMaking
   | RejectPrivateMatchEntry
+  | KickedByNewConnection
   | Error;
 
 /** pingの応答 */
@@ -101,6 +102,11 @@ export type CouldNotPrivateMatchMaking = {
 /** 何らかの理由でプライベートマッチに参加できなかった */
 export type RejectPrivateMatchEntry = {
   action: "reject-private-match-entry";
+};
+
+/** 新規接続によりキックされた通知 */
+export type KickedByNewConnection = {
+  action: "kicked-by-new-connection";
 };
 
 /** エラー */

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -16,7 +16,6 @@ export type WebsocketResponse =
   | CreatedPrivateMatchRoom
   | CouldNotPrivateMatchMaking
   | RejectPrivateMatchEntry
-  | KickedByNewConnection
   | Error;
 
 /** pingの応答 */
@@ -102,11 +101,6 @@ export type CouldNotPrivateMatchMaking = {
 /** 何らかの理由でプライベートマッチに参加できなかった */
 export type RejectPrivateMatchEntry = {
   action: "reject-private-match-entry";
-};
-
-/** 新規接続によりキックされた通知 */
-export type KickedByNewConnection = {
-  action: "kicked-by-new-connection";
 };
 
 /** エラー */


### PR DESCRIPTION
## 概要
- 1ユーザー1接続の管理フローを追加
- ユーザーIDによる接続クエリの追加と、接続クエリ命名の改善
- 古い接続のクリーンアップ挙動と関連レスポンス型を改善
- 可読性向上のため、関連フォーマットおよび Serverless 定義をリファクタリング

## 変更内容
- 新規接続時に古い接続を削除する処理を実装
- クリーンアップ処理を `Promise.allSettled` で改善
- 接続管理に合わせて IAM ポリシーと DynamoDB スキーマ利用を更新

## 補足
- ブランチ: `feature/one-user-one-connection`
- ベース: `develop`
