### PR TITLE
chore: update base image to node:24.13.1-trixie-slim in Dockerfile

### DIFF
--- a/packages/backend-app/matchMake.Dockerfile
+++ b/packages/backend-app/matchMake.Dockerfile
@@ -1,5 +1,5 @@
 # docker buildの前にbuild:match-makeを実行すること
-FROM node:24.13.0-bookworm-slim
+FROM node:24.13.1-trixie-slim
 WORKDIR /usr/src/app
 COPY ./ /usr/src/app
 # SIGTERMを適切に処理できるように、


### PR DESCRIPTION
This pull request updates the base image version used in the `matchMake.Dockerfile` to ensure compatibility and security.

- Dockerfile update:
  * Changed the base image from `node:24.13.0-bookworm-slim` to `node:24.13.1-trixie-slim` in `packages/backend-app/matchMake.Dockerfile` for improved stability and security.