### PR TITLE
Signalキャッシュサーバーにeslintを導入した

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19433,12 +19433,12 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "eslint": "^10.0.2",
-        "eslint-plugin-jest": "^29.15.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "npm-run-all": "^4.1.5",
         "prettier": "3.8.1",
         "rimraf": "^6.1.3",
-        "serverless": "^4.33.0"
+        "serverless": "^4.33.0",
+        "typescript-eslint": "^8.56.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19431,6 +19431,10 @@
       "version": "1.19.4",
       "license": "MIT",
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "eslint": "^10.0.2",
+        "eslint-plugin-jest": "^29.15.0",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "npm-run-all": "^4.1.5",
         "prettier": "3.8.1",
         "rimraf": "^6.1.3",

--- a/packages/webrtc-signal-cache/eslint.config.mjs
+++ b/packages/webrtc-signal-cache/eslint.config.mjs
@@ -1,0 +1,34 @@
+import eslint from "@eslint/js";
+import jest from "eslint-plugin-jest";
+import simpleImportSort from "eslint-plugin-simple-import-sort";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: [
+      "node_modules/*",
+      "coverage/*",
+      ".webpack/*",
+      ".serverless/*",
+      "*webpack.config.js",
+    ],
+  },
+  eslint.configs.recommended,
+  tseslint.configs.recommended,
+  {
+    plugins: {
+      "simple-import-sort": simpleImportSort,
+    },
+    rules: {
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error",
+    },
+  },
+  {
+    files: ["test/**"],
+    ...jest.configs["flat/recommended"],
+    rules: {
+      ...jest.configs["flat/recommended"].rules,
+    },
+  },
+);

--- a/packages/webrtc-signal-cache/eslint.config.mjs
+++ b/packages/webrtc-signal-cache/eslint.config.mjs
@@ -1,17 +1,10 @@
 import eslint from "@eslint/js";
-import jest from "eslint-plugin-jest";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   {
-    ignores: [
-      "node_modules/*",
-      "coverage/*",
-      ".webpack/*",
-      ".serverless/*",
-      "*webpack.config.js",
-    ],
+    ignores: ["node_modules/*", ".serverless/*"],
   },
   eslint.configs.recommended,
   tseslint.configs.recommended,
@@ -22,13 +15,6 @@ export default tseslint.config(
     rules: {
       "simple-import-sort/imports": "error",
       "simple-import-sort/exports": "error",
-    },
-  },
-  {
-    files: ["test/**"],
-    ...jest.configs["flat/recommended"],
-    rules: {
-      ...jest.configs["flat/recommended"].rules,
     },
   },
 );

--- a/packages/webrtc-signal-cache/package.json
+++ b/packages/webrtc-signal-cache/package.json
@@ -6,12 +6,12 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "eslint": "^10.0.2",
-    "eslint-plugin-jest": "^29.15.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "npm-run-all": "^4.1.5",
     "prettier": "3.8.1",
     "rimraf": "^6.1.3",
-    "serverless": "^4.33.0"
+    "serverless": "^4.33.0",
+    "typescript-eslint": "^8.56.1"
   },
   "license": "MIT",
   "private": true,

--- a/packages/webrtc-signal-cache/package.json
+++ b/packages/webrtc-signal-cache/package.json
@@ -4,6 +4,10 @@
   "version": "1.19.4",
   "author": "Y.Takeuchi",
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.0.2",
+    "eslint-plugin-jest": "^29.15.0",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "npm-run-all": "^4.1.5",
     "prettier": "3.8.1",
     "rimraf": "^6.1.3",
@@ -16,6 +20,8 @@
     "clean": "rimraf .serverless",
     "code-format": "prettier . --write",
     "code-format-check": "prettier . --check",
+    "lint": "eslint .",
+    "lint-fix": "eslint --fix .",
     "transpile": "sls package",
     "type-check": "tsc --noEmit"
   }


### PR DESCRIPTION
This pull request sets up ESLint for the `webrtc-signal-cache` package, adding configuration and dependencies for linting and import sorting. It also introduces new npm scripts for running lint checks and auto-fixing issues.

**ESLint integration and configuration:**

* Added a new ESLint configuration file (`eslint.config.mjs`) with recommended settings and the `simple-import-sort` plugin for import/export sorting.
* Added ESLint-related dependencies (`eslint`, `@eslint/js`, `eslint-plugin-simple-import-sort`, `typescript-eslint`) to `devDependencies` in `package.json`.

**Developer workflow improvements:**

* Added new npm scripts `lint` and `lint-fix` to `package.json` for running ESLint and auto-fixing lint errors.