### PR TITLE
backend-appのレスポンスデータ型をリファクタリングした

### DIFF
--- a/packages/backend-app/src/api-gateway/notifier.ts
+++ b/packages/backend-app/src/api-gateway/notifier.ts
@@ -1,7 +1,7 @@
 import { ApiGatewayManagementApi } from "@aws-sdk/client-apigatewaymanagementapi";
 import { TextEncoder } from "util";
 
-import type { WebsocketResponse } from "../response/websocket-response";
+import type { WebsocketResponse } from "../response";
 
 /** メッセージ通知 */
 export class Notifier {

--- a/packages/backend-app/src/battle-progress-polling.ts
+++ b/packages/backend-app/src/battle-progress-polling.ts
@@ -21,7 +21,7 @@ import { sendCommandSuccess as webSocketAPIResponseOfSendCommandSuccess } from "
 import { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parseBattleProgressPolling } from "./request/battle-progress-polling";
-import { invalidRequestBodyError } from "./response/invalid-request-body-error";
+import { INVALID_REQUEST_BODY_ERROR } from "./response/error";
 import { NOT_READY_BATTLE_PROGRESS } from "./response/not-ready-battle-progress";
 
 /** AWSリージョン */
@@ -71,7 +71,7 @@ async function endWithInvalidRequestBody(
 ): Promise<WebsocketAPIResponse> {
   await notifier.notifyToClient(
     event.requestContext.connectionId,
-    invalidRequestBodyError,
+    INVALID_REQUEST_BODY_ERROR,
   );
   return invalidRequestBody;
 }

--- a/packages/backend-app/src/battle-progress-polling.ts
+++ b/packages/backend-app/src/battle-progress-polling.ts
@@ -22,7 +22,7 @@ import { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parseBattleProgressPolling } from "./request/battle-progress-polling";
 import { invalidRequestBodyError } from "./response/invalid-request-body-error";
-import { notReadyBattleProgress } from "./response/not-ready-battle-progress";
+import { NOT_READY_BATTLE_PROGRESS } from "./response/not-ready-battle-progress";
 
 /** AWSリージョン */
 const AWS_REGION = process.env.AWS_REGION ?? "";
@@ -86,7 +86,7 @@ async function endWithNotReadyBattleProgress(
 ): Promise<WebsocketAPIResponse> {
   await notifier.notifyToClient(
     event.requestContext.connectionId,
-    notReadyBattleProgress,
+    NOT_READY_BATTLE_PROGRESS,
   );
   return webSocketAPIResponseOfNotReadyBattleProgress;
 }

--- a/packages/backend-app/src/create-private-match-room.ts
+++ b/packages/backend-app/src/create-private-match-room.ts
@@ -11,7 +11,7 @@ import { extractUserFromWebSocketAuthorizer } from "./lambda/extract-user";
 import { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parseCreatePrivateMatchRoom } from "./request/create-private-match-room";
-import { Error } from "./response/websocket-response";
+import { Error } from "./response/error";
 
 const AWS_REGION = process.env.AWS_REGION ?? "";
 const SERVICE = process.env.SERVICE ?? "";

--- a/packages/backend-app/src/enter-casual-match.ts
+++ b/packages/backend-app/src/enter-casual-match.ts
@@ -9,8 +9,8 @@ import { extractUserFromWebSocketAuthorizer } from "./lambda/extract-user";
 import type { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import type { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parseEnterCasualMatch } from "./request/enter-casual-match";
-import type { Error } from "./response/websocket-response";
 import type { EnteredCasualMatch } from "./response/entered-casual-match";
+import type { Error } from "./response/websocket-response";
 
 const AWS_REGION = process.env.AWS_REGION ?? "";
 const SERVICE = process.env.SERVICE ?? "";

--- a/packages/backend-app/src/enter-casual-match.ts
+++ b/packages/backend-app/src/enter-casual-match.ts
@@ -9,7 +9,8 @@ import { extractUserFromWebSocketAuthorizer } from "./lambda/extract-user";
 import type { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import type { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parseEnterCasualMatch } from "./request/enter-casual-match";
-import type { EnteredCasualMatch, Error } from "./response/websocket-response";
+import type { Error } from "./response/websocket-response";
+import type { EnteredCasualMatch } from "./response/entered-casual-match";
 
 const AWS_REGION = process.env.AWS_REGION ?? "";
 const SERVICE = process.env.SERVICE ?? "";

--- a/packages/backend-app/src/enter-casual-match.ts
+++ b/packages/backend-app/src/enter-casual-match.ts
@@ -10,7 +10,7 @@ import type { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import type { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parseEnterCasualMatch } from "./request/enter-casual-match";
 import type { EnteredCasualMatch } from "./response/entered-casual-match";
-import type { Error } from "./response/websocket-response";
+import type { Error } from "./response/error";
 
 const AWS_REGION = process.env.AWS_REGION ?? "";
 const SERVICE = process.env.SERVICE ?? "";

--- a/packages/backend-app/src/enter-private-match-room.ts
+++ b/packages/backend-app/src/enter-private-match-room.ts
@@ -10,9 +10,7 @@ import { extractUserFromWebSocketAuthorizer } from "./lambda/extract-user";
 import { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parseEnterPrivateMatchRoom } from "./request/enter-private-match-room";
-import type {
-  Error,
-} from "./response/websocket-response";
+import type { Error } from "./response/error";
 import type { RejectPrivateMatchEntry } from "./response/reject-private-match-entry";
 
 const AWS_REGION = process.env.AWS_REGION ?? "";

--- a/packages/backend-app/src/enter-private-match-room.ts
+++ b/packages/backend-app/src/enter-private-match-room.ts
@@ -12,8 +12,8 @@ import { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parseEnterPrivateMatchRoom } from "./request/enter-private-match-room";
 import type {
   Error,
-  RejectPrivateMatchEntry,
 } from "./response/websocket-response";
+import type { RejectPrivateMatchEntry } from "./response/reject-private-match-entry";
 
 const AWS_REGION = process.env.AWS_REGION ?? "";
 const SERVICE = process.env.SERVICE ?? "";

--- a/packages/backend-app/src/match-making-polling.ts
+++ b/packages/backend-app/src/match-making-polling.ts
@@ -10,7 +10,7 @@ import { createDynamoBattles } from "./dynamo-db/create-dynamo-battles";
 import { createDynamoCasualMatchEntries } from "./dynamo-db/create-dynamo-casual-match-entries";
 import { createDynamoConnections } from "./dynamo-db/create-dynamo-connections";
 import { createDynamoDBDocument } from "./dynamo-db/dynamo-db-document";
-import { createBattleStart } from "./response/create-battle-start";
+import { createBattleStart } from "./response/battle-start";
 import { wait } from "./wait/wait";
 
 dotenv.config();

--- a/packages/backend-app/src/ping.ts
+++ b/packages/backend-app/src/ping.ts
@@ -3,7 +3,7 @@ import { createApiGatewayManagementApi } from "./api-gateway/management";
 import { Notifier } from "./api-gateway/notifier";
 import type { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import type { WebsocketAPIResponse } from "./lambda/websocket-api-response";
-import type { Pong } from "./response/websocket-response";
+import type { Pong } from "./response/pong";
 
 const AWS_REGION = process.env.AWS_REGION ?? "";
 const STAGE = process.env.STAGE ?? "";

--- a/packages/backend-app/src/private-match-make-polling.ts
+++ b/packages/backend-app/src/private-match-make-polling.ts
@@ -18,7 +18,7 @@ import { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parsePrivateMatchMakePolling } from "./request/private-match-make-polling";
 import { createBattleStart } from "./response/battle-start";
 import { CLOUD_NOT_PRIVATE_MATCH_MAKE } from "./response/cloud-not-private-match-make";
-import { invalidRequestBodyError } from "./response/invalid-request-body-error";
+import { INVALID_REQUEST_BODY_ERROR } from "./response/error";
 import { REJECT_PRIVATE_MATCH_ENTRY } from "./response/reject-private-match-entry";
 
 const AWS_REGION = process.env.AWS_REGION ?? "";
@@ -61,7 +61,7 @@ export async function privateMatchMakePolling(
   if (!data) {
     await notifier.notifyToClient(
       event.requestContext.connectionId,
-      invalidRequestBodyError,
+      INVALID_REQUEST_BODY_ERROR,
     );
     return invalidRequestBody;
   }

--- a/packages/backend-app/src/private-match-make-polling.ts
+++ b/packages/backend-app/src/private-match-make-polling.ts
@@ -17,7 +17,7 @@ import { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parsePrivateMatchMakePolling } from "./request/private-match-make-polling";
 import { createBattleStart } from "./response/battle-start";
-import { cloudNotPrivateMatchMake } from "./response/cloud-not-private-match-make";
+import { CLOUD_NOT_PRIVATE_MATCH_MAKE } from "./response/cloud-not-private-match-make";
 import { invalidRequestBodyError } from "./response/invalid-request-body-error";
 import { rejectPrivateMatchEntry } from "./response/reject-private-match-entry";
 
@@ -76,7 +76,7 @@ export async function privateMatchMakePolling(
   if (!room || !isValidPrivateMatch({ owner: user, room, entries })) {
     await notifier.notifyToClient(
       event.requestContext.connectionId,
-      cloudNotPrivateMatchMake,
+      CLOUD_NOT_PRIVATE_MATCH_MAKE,
     );
     return endPrivateMatchMakePolling;
   }
@@ -85,7 +85,7 @@ export async function privateMatchMakePolling(
   if (!matching) {
     await notifier.notifyToClient(
       event.requestContext.connectionId,
-      cloudNotPrivateMatchMake,
+      CLOUD_NOT_PRIVATE_MATCH_MAKE,
     );
     return endPrivateMatchMakePolling;
   }

--- a/packages/backend-app/src/private-match-make-polling.ts
+++ b/packages/backend-app/src/private-match-make-polling.ts
@@ -16,8 +16,8 @@ import { invalidRequestBody } from "./lambda/invalid-request-body";
 import { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parsePrivateMatchMakePolling } from "./request/private-match-make-polling";
-import { cloudNotPrivateMatchMake } from "./response/cloud-not-private-match-make";
 import { createBattleStart } from "./response/battle-start";
+import { cloudNotPrivateMatchMake } from "./response/cloud-not-private-match-make";
 import { invalidRequestBodyError } from "./response/invalid-request-body-error";
 import { rejectPrivateMatchEntry } from "./response/reject-private-match-entry";
 

--- a/packages/backend-app/src/private-match-make-polling.ts
+++ b/packages/backend-app/src/private-match-make-polling.ts
@@ -17,7 +17,7 @@ import { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parsePrivateMatchMakePolling } from "./request/private-match-make-polling";
 import { cloudNotPrivateMatchMake } from "./response/cloud-not-private-match-make";
-import { createBattleStart } from "./response/create-battle-start";
+import { createBattleStart } from "./response/battle-start";
 import { invalidRequestBodyError } from "./response/invalid-request-body-error";
 import { rejectPrivateMatchEntry } from "./response/reject-private-match-entry";
 

--- a/packages/backend-app/src/private-match-make-polling.ts
+++ b/packages/backend-app/src/private-match-make-polling.ts
@@ -19,7 +19,7 @@ import { parsePrivateMatchMakePolling } from "./request/private-match-make-polli
 import { createBattleStart } from "./response/battle-start";
 import { CLOUD_NOT_PRIVATE_MATCH_MAKE } from "./response/cloud-not-private-match-make";
 import { invalidRequestBodyError } from "./response/invalid-request-body-error";
-import { rejectPrivateMatchEntry } from "./response/reject-private-match-entry";
+import { REJECT_PRIVATE_MATCH_ENTRY } from "./response/reject-private-match-entry";
 
 const AWS_REGION = process.env.AWS_REGION ?? "";
 const SERVICE = process.env.SERVICE ?? "";
@@ -102,7 +102,7 @@ export async function privateMatchMakePolling(
     ),
     ...notChosenConnections.map((v) => dynamoConnections.put(v)),
     ...notChosenConnections.map(({ connectionId }) =>
-      notifier.notifyToClient(connectionId, rejectPrivateMatchEntry),
+      notifier.notifyToClient(connectionId, REJECT_PRIVATE_MATCH_ENTRY),
     ),
     ...entries.map(({ roomID, userID }) =>
       dynamoPrivateMatchEntries.delete(roomID, userID),

--- a/packages/backend-app/src/response/accept-command.ts
+++ b/packages/backend-app/src/response/accept-command.ts
@@ -1,0 +1,4 @@
+/** コマンド受取通知 */
+export type AcceptCommand = {
+  action: "accept-command";
+};

--- a/packages/backend-app/src/response/battle-end.ts
+++ b/packages/backend-app/src/response/battle-end.ts
@@ -1,0 +1,8 @@
+import { GameState } from "gbraver-burst-core";
+
+/** バトル終了 */
+export type BattleEnd = {
+  action: "battle-end";
+  /** 更新されたゲームステート */
+  update: GameState[];
+};

--- a/packages/backend-app/src/response/battle-progressed.ts
+++ b/packages/backend-app/src/response/battle-progressed.ts
@@ -1,0 +1,11 @@
+import { GameState } from "gbraver-burst-core";
+import { FlowID } from "../core/battle";
+
+/** バトル進行通知 */
+export type BattleProgressed = {
+  action: "battle-progressed";
+  /** 発行されたフローID */
+  flowID: FlowID;
+  /** 更新されたゲームステート */
+  update: GameState[];
+};

--- a/packages/backend-app/src/response/battle-progressed.ts
+++ b/packages/backend-app/src/response/battle-progressed.ts
@@ -1,4 +1,5 @@
 import { GameState } from "gbraver-burst-core";
+
 import { FlowID } from "../core/battle";
 
 /** バトル進行通知 */

--- a/packages/backend-app/src/response/battle-start.ts
+++ b/packages/backend-app/src/response/battle-start.ts
@@ -1,4 +1,4 @@
-import { Player, GameState } from "gbraver-burst-core";
+import { GameState, Player } from "gbraver-burst-core";
 
 import { Battle, BattleID, BattlePlayer, FlowID } from "../core/battle";
 import { toPlayer } from "../core/to-player";

--- a/packages/backend-app/src/response/battle-start.ts
+++ b/packages/backend-app/src/response/battle-start.ts
@@ -1,7 +1,25 @@
-import type { Battle, BattlePlayer } from "../core/battle";
+import { Player, GameState } from "gbraver-burst-core";
+
+import { Battle, BattleID, BattlePlayer, FlowID } from "../core/battle";
 import { toPlayer } from "../core/to-player";
-import type { UserID } from "../core/user";
-import type { BattleStart } from "./websocket-response";
+import { UserID } from "../core/user";
+
+/** 戦闘開始 */
+export type BattleStart = {
+  action: "battle-start";
+  /** プレイヤー情報 */
+  player: Player;
+  /** 敵情報 */
+  enemy: Player;
+  /** 戦闘ID */
+  battleID: BattleID;
+  /** ステートヒストリー */
+  stateHistory: GameState[];
+  /** フローID */
+  flowID: FlowID;
+  /** 戦闘進捗ポーリングを実行する側か否か、trueでポーリングをする */
+  isPoller: boolean;
+};
 
 /**
  * 戦闘開始オブジェクトを生成するヘルパー関数

--- a/packages/backend-app/src/response/cloud-not-private-match-make.ts
+++ b/packages/backend-app/src/response/cloud-not-private-match-make.ts
@@ -1,6 +1,9 @@
-import { CouldNotPrivateMatchMaking } from "./websocket-response";
+/** オーナーがプライベートマッチングできなかった */
+export type CouldNotPrivateMatchMaking = {
+  action: "cloud-not-private-match-making";
+};
 
 /** オーナーがプライベートマッチングできなかった */
-export const cloudNotPrivateMatchMake: CouldNotPrivateMatchMaking = {
+export const CLOUD_NOT_PRIVATE_MATCH_MAKE: CouldNotPrivateMatchMaking = {
   action: "cloud-not-private-match-making",
 };

--- a/packages/backend-app/src/response/cloud-not-private-match-make.ts
+++ b/packages/backend-app/src/response/cloud-not-private-match-make.ts
@@ -3,7 +3,7 @@ export type CouldNotPrivateMatchMaking = {
   action: "cloud-not-private-match-making";
 };
 
-/** オーナーがプライベートマッチングできなかった */
+/** オーナーがプライベートマッチングできなかった（定数） */
 export const CLOUD_NOT_PRIVATE_MATCH_MAKE: CouldNotPrivateMatchMaking = {
   action: "cloud-not-private-match-making",
 };

--- a/packages/backend-app/src/response/created-private-match-room.ts
+++ b/packages/backend-app/src/response/created-private-match-room.ts
@@ -1,0 +1,8 @@
+import { PrivateMatchRoomID } from "../core/private-match-room";
+
+/** オーナーがプライベートマッチルーム作成に成功した */
+export type CreatedPrivateMatchRoom = {
+  action: "created-private-match-room";
+  /** 作成したルームID */
+  roomID: PrivateMatchRoomID;
+};

--- a/packages/backend-app/src/response/entered-casual-match.ts
+++ b/packages/backend-app/src/response/entered-casual-match.ts
@@ -1,0 +1,4 @@
+/** カジュアルマッチ入室成功 */
+export type EnteredCasualMatch = {
+  action: "entered-casual-match";
+};

--- a/packages/backend-app/src/response/error.ts
+++ b/packages/backend-app/src/response/error.ts
@@ -1,0 +1,12 @@
+/** エラー */
+export type Error = {
+  action: "error";
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  error: any;
+};
+
+/** 不正なリクエストボディなのでエラー（定数） */
+export const INVALID_REQUEST_BODY_ERROR: Error = {
+  action: "error",
+  error: "invalid request body",
+};

--- a/packages/backend-app/src/response/index.ts
+++ b/packages/backend-app/src/response/index.ts
@@ -1,16 +1,15 @@
-
 import { AcceptCommand } from "./accept-command";
+import { BattleEnd } from "./battle-end";
+import { BattleProgressed } from "./battle-progressed";
 import { BattleStart } from "./battle-start";
+import { CouldNotPrivateMatchMaking } from "./cloud-not-private-match-make";
+import { CreatedPrivateMatchRoom } from "./created-private-match-room";
 import { EnteredCasualMatch } from "./entered-casual-match";
+import { Error } from "./error";
 import { NotReadyBattleProgress } from "./not-ready-battle-progress";
 import { Pong } from "./pong";
-import { BattleProgressed } from "./battle-progressed";
-import { SuddenlyBattleEnd } from "./suddenly-battle-end";
-import { BattleEnd } from "./battle-end";
-import { CreatedPrivateMatchRoom } from "./created-private-match-room";
-import { CouldNotPrivateMatchMaking } from "./cloud-not-private-match-make";
 import { RejectPrivateMatchEntry } from "./reject-private-match-entry";
-import { Error } from "./error";
+import { SuddenlyBattleEnd } from "./suddenly-battle-end";
 
 /** websocketがクライアントに返すデータ */
 export type WebsocketResponse =
@@ -26,5 +25,3 @@ export type WebsocketResponse =
   | CouldNotPrivateMatchMaking
   | RejectPrivateMatchEntry
   | Error;
-
-

--- a/packages/backend-app/src/response/invalid-request-body-error.ts
+++ b/packages/backend-app/src/response/invalid-request-body-error.ts
@@ -1,7 +1,0 @@
-import { Error } from "./websocket-response";
-
-/** 不正なリクエストボディなのでエラー */
-export const invalidRequestBodyError: Error = {
-  action: "error",
-  error: "invalid request body",
-};

--- a/packages/backend-app/src/response/not-ready-battle-progress.ts
+++ b/packages/backend-app/src/response/not-ready-battle-progress.ts
@@ -1,6 +1,9 @@
-import type { NotReadyBattleProgress } from "./websocket-response";
+/** バトル進行の準備ができていない */
+export type NotReadyBattleProgress = {
+  action: "not-ready-battle-progress";
+};
 
-/** クライアント通知 コマンド入力が完了していない */
-export const notReadyBattleProgress: NotReadyBattleProgress = {
+/** バトル進行の準備ができていない（定数） */
+export const NOT_READY_BATTLE_PROGRESS: NotReadyBattleProgress = {
   action: "not-ready-battle-progress",
 };

--- a/packages/backend-app/src/response/pong.ts
+++ b/packages/backend-app/src/response/pong.ts
@@ -1,0 +1,6 @@
+/** pingの応答 */
+export type Pong = {
+  action: "pong";
+  /** メッセージ */
+  message: string;
+};

--- a/packages/backend-app/src/response/reject-private-match-entry.ts
+++ b/packages/backend-app/src/response/reject-private-match-entry.ts
@@ -1,6 +1,9 @@
-import { RejectPrivateMatchEntry } from "./websocket-response";
-
 /** 何らかの理由でプライベートマッチに参加できなかった */
-export const rejectPrivateMatchEntry: RejectPrivateMatchEntry = {
+export type RejectPrivateMatchEntry = {
+  action: "reject-private-match-entry";
+};
+
+/** 何らかの理由でプライベートマッチに参加できなかった（定数） */
+export const REJECT_PRIVATE_MATCH_ENTRY: RejectPrivateMatchEntry = {
   action: "reject-private-match-entry",
 };

--- a/packages/backend-app/src/response/suddenly-battle-end.ts
+++ b/packages/backend-app/src/response/suddenly-battle-end.ts
@@ -1,0 +1,4 @@
+/** バトル強制終了 */
+export type SuddenlyBattleEnd = {
+  action: "suddenly-battle-end";
+};

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -8,6 +8,7 @@ import { BattleProgressed } from "./battle-progressed";
 import { SuddenlyBattleEnd } from "./suddenly-battle-end";
 import { BattleEnd } from "./battle-end";
 import { CreatedPrivateMatchRoom } from "./created-private-match-room";
+import { CouldNotPrivateMatchMaking } from "./cloud-not-private-match-make";
 
 /** websocketがクライアントに返すデータ */
 export type WebsocketResponse =
@@ -23,11 +24,6 @@ export type WebsocketResponse =
   | CouldNotPrivateMatchMaking
   | RejectPrivateMatchEntry
   | Error;
-
-/** オーナーがプライベートマッチングできなかった */
-export type CouldNotPrivateMatchMaking = {
-  action: "cloud-not-private-match-making";
-};
 
 /** 何らかの理由でプライベートマッチに参加できなかった */
 export type RejectPrivateMatchEntry = {

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -1,11 +1,12 @@
-import type { GameState } from "gbraver-burst-core";
+import { GameState } from "gbraver-burst-core";
 
-import type { FlowID } from "../core/battle";
+import { FlowID } from "../core/battle";
 import { PrivateMatchRoomID } from "../core/private-match-room";
-import { Pong } from "./pong";
-import { EnteredCasualMatch } from "./entered-casual-match";
 import { AcceptCommand } from "./accept-command";
 import { BattleStart } from "./battle-start";
+import { EnteredCasualMatch } from "./entered-casual-match";
+import { NotReadyBattleProgress } from "./not-ready-battle-progress";
+import { Pong } from "./pong";
 
 /** websocketがクライアントに返すデータ */
 export type WebsocketResponse =
@@ -21,11 +22,6 @@ export type WebsocketResponse =
   | CouldNotPrivateMatchMaking
   | RejectPrivateMatchEntry
   | Error;
-
-/** バトル進行の準備ができていない */
-export type NotReadyBattleProgress = {
-  action: "not-ready-battle-progress";
-};
 
 /** バトル進行通知 */
 export type BattleProgressed = {

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -1,10 +1,11 @@
-import type { GameState, Player } from "gbraver-burst-core";
+import type { GameState } from "gbraver-burst-core";
 
-import type { BattleID, FlowID } from "../core/battle";
+import type { FlowID } from "../core/battle";
 import { PrivateMatchRoomID } from "../core/private-match-room";
 import { Pong } from "./pong";
 import { EnteredCasualMatch } from "./entered-casual-match";
 import { AcceptCommand } from "./accept-command";
+import { BattleStart } from "./battle-start";
 
 /** websocketがクライアントに返すデータ */
 export type WebsocketResponse =
@@ -20,23 +21,6 @@ export type WebsocketResponse =
   | CouldNotPrivateMatchMaking
   | RejectPrivateMatchEntry
   | Error;
-
-/** 戦闘開始 */
-export type BattleStart = {
-  action: "battle-start";
-  /** プレイヤー情報 */
-  player: Player;
-  /** 敵情報 */
-  enemy: Player;
-  /** 戦闘ID */
-  battleID: BattleID;
-  /** ステートヒストリー */
-  stateHistory: GameState[];
-  /** フローID */
-  flowID: FlowID;
-  /** 戦闘進捗ポーリングを実行する側か否か、trueでポーリングをする */
-  isPoller: boolean;
-};
 
 /** バトル進行の準備ができていない */
 export type NotReadyBattleProgress = {

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -2,6 +2,7 @@ import type { GameState, Player } from "gbraver-burst-core";
 
 import type { BattleID, FlowID } from "../core/battle";
 import { PrivateMatchRoomID } from "../core/private-match-room";
+import { Pong } from "./pong";
 
 /** websocketがクライアントに返すデータ */
 export type WebsocketResponse =
@@ -17,12 +18,6 @@ export type WebsocketResponse =
   | CouldNotPrivateMatchMaking
   | RejectPrivateMatchEntry
   | Error;
-
-/** pingの応答 */
-export type Pong = {
-  action: "pong";
-  message: string;
-};
 
 /** カジュアルマッチ入室成功 */
 export type EnteredCasualMatch = {

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -9,6 +9,7 @@ import { SuddenlyBattleEnd } from "./suddenly-battle-end";
 import { BattleEnd } from "./battle-end";
 import { CreatedPrivateMatchRoom } from "./created-private-match-room";
 import { CouldNotPrivateMatchMaking } from "./cloud-not-private-match-make";
+import { RejectPrivateMatchEntry } from "./reject-private-match-entry";
 
 /** websocketがクライアントに返すデータ */
 export type WebsocketResponse =
@@ -24,11 +25,6 @@ export type WebsocketResponse =
   | CouldNotPrivateMatchMaking
   | RejectPrivateMatchEntry
   | Error;
-
-/** 何らかの理由でプライベートマッチに参加できなかった */
-export type RejectPrivateMatchEntry = {
-  action: "reject-private-match-entry";
-};
 
 /** エラー */
 export type Error = {

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -1,5 +1,4 @@
 
-import { PrivateMatchRoomID } from "../core/private-match-room";
 import { AcceptCommand } from "./accept-command";
 import { BattleStart } from "./battle-start";
 import { EnteredCasualMatch } from "./entered-casual-match";
@@ -8,6 +7,7 @@ import { Pong } from "./pong";
 import { BattleProgressed } from "./battle-progressed";
 import { SuddenlyBattleEnd } from "./suddenly-battle-end";
 import { BattleEnd } from "./battle-end";
+import { CreatedPrivateMatchRoom } from "./created-private-match-room";
 
 /** websocketがクライアントに返すデータ */
 export type WebsocketResponse =
@@ -23,13 +23,6 @@ export type WebsocketResponse =
   | CouldNotPrivateMatchMaking
   | RejectPrivateMatchEntry
   | Error;
-
-/** オーナーがプライベートマッチルーム作成に成功した */
-export type CreatedPrivateMatchRoom = {
-  action: "created-private-match-room";
-  /** 作成したルームID */
-  roomID: PrivateMatchRoomID;
-};
 
 /** オーナーがプライベートマッチングできなかった */
 export type CouldNotPrivateMatchMaking = {

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -1,4 +1,3 @@
-import { GameState } from "gbraver-burst-core";
 
 import { PrivateMatchRoomID } from "../core/private-match-room";
 import { AcceptCommand } from "./accept-command";
@@ -8,6 +7,7 @@ import { NotReadyBattleProgress } from "./not-ready-battle-progress";
 import { Pong } from "./pong";
 import { BattleProgressed } from "./battle-progressed";
 import { SuddenlyBattleEnd } from "./suddenly-battle-end";
+import { BattleEnd } from "./battle-end";
 
 /** websocketがクライアントに返すデータ */
 export type WebsocketResponse =
@@ -23,14 +23,6 @@ export type WebsocketResponse =
   | CouldNotPrivateMatchMaking
   | RejectPrivateMatchEntry
   | Error;
-
-/** バトル終了 */
-export type BattleEnd = {
-  action: "battle-end";
-
-  /** 更新されたゲームステート */
-  update: GameState[];
-};
 
 /** オーナーがプライベートマッチルーム作成に成功した */
 export type CreatedPrivateMatchRoom = {

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -1,12 +1,12 @@
 import { GameState } from "gbraver-burst-core";
 
-import { FlowID } from "../core/battle";
 import { PrivateMatchRoomID } from "../core/private-match-room";
 import { AcceptCommand } from "./accept-command";
 import { BattleStart } from "./battle-start";
 import { EnteredCasualMatch } from "./entered-casual-match";
 import { NotReadyBattleProgress } from "./not-ready-battle-progress";
 import { Pong } from "./pong";
+import { BattleProgressed } from "./battle-progressed";
 
 /** websocketがクライアントに返すデータ */
 export type WebsocketResponse =
@@ -22,17 +22,6 @@ export type WebsocketResponse =
   | CouldNotPrivateMatchMaking
   | RejectPrivateMatchEntry
   | Error;
-
-/** バトル進行通知 */
-export type BattleProgressed = {
-  action: "battle-progressed";
-
-  /** 発行されたフローID */
-  flowID: FlowID;
-
-  /** 更新されたゲームステート */
-  update: GameState[];
-};
 
 /** バトル強制終了 */
 export type SuddenlyBattleEnd = {

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -7,6 +7,7 @@ import { EnteredCasualMatch } from "./entered-casual-match";
 import { NotReadyBattleProgress } from "./not-ready-battle-progress";
 import { Pong } from "./pong";
 import { BattleProgressed } from "./battle-progressed";
+import { SuddenlyBattleEnd } from "./suddenly-battle-end";
 
 /** websocketがクライアントに返すデータ */
 export type WebsocketResponse =
@@ -22,11 +23,6 @@ export type WebsocketResponse =
   | CouldNotPrivateMatchMaking
   | RejectPrivateMatchEntry
   | Error;
-
-/** バトル強制終了 */
-export type SuddenlyBattleEnd = {
-  action: "suddenly-battle-end";
-};
 
 /** バトル終了 */
 export type BattleEnd = {

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -3,6 +3,7 @@ import type { GameState, Player } from "gbraver-burst-core";
 import type { BattleID, FlowID } from "../core/battle";
 import { PrivateMatchRoomID } from "../core/private-match-room";
 import { Pong } from "./pong";
+import { EnteredCasualMatch } from "./entered-casual-match";
 
 /** websocketがクライアントに返すデータ */
 export type WebsocketResponse =
@@ -18,11 +19,6 @@ export type WebsocketResponse =
   | CouldNotPrivateMatchMaking
   | RejectPrivateMatchEntry
   | Error;
-
-/** カジュアルマッチ入室成功 */
-export type EnteredCasualMatch = {
-  action: "entered-casual-match";
-};
 
 /** コマンド受取通知 */
 export type AcceptCommand = {

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -10,6 +10,7 @@ import { BattleEnd } from "./battle-end";
 import { CreatedPrivateMatchRoom } from "./created-private-match-room";
 import { CouldNotPrivateMatchMaking } from "./cloud-not-private-match-make";
 import { RejectPrivateMatchEntry } from "./reject-private-match-entry";
+import { Error } from "./error";
 
 /** websocketがクライアントに返すデータ */
 export type WebsocketResponse =
@@ -26,10 +27,4 @@ export type WebsocketResponse =
   | RejectPrivateMatchEntry
   | Error;
 
-/** エラー */
-export type Error = {
-  action: "error";
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  error: any;
-  /* eslint-enable */
-};
+

--- a/packages/backend-app/src/response/websocket-response.ts
+++ b/packages/backend-app/src/response/websocket-response.ts
@@ -4,6 +4,7 @@ import type { BattleID, FlowID } from "../core/battle";
 import { PrivateMatchRoomID } from "../core/private-match-room";
 import { Pong } from "./pong";
 import { EnteredCasualMatch } from "./entered-casual-match";
+import { AcceptCommand } from "./accept-command";
 
 /** websocketがクライアントに返すデータ */
 export type WebsocketResponse =
@@ -20,30 +21,19 @@ export type WebsocketResponse =
   | RejectPrivateMatchEntry
   | Error;
 
-/** コマンド受取通知 */
-export type AcceptCommand = {
-  action: "accept-command";
-};
-
 /** 戦闘開始 */
 export type BattleStart = {
   action: "battle-start";
-
   /** プレイヤー情報 */
   player: Player;
-
   /** 敵情報 */
   enemy: Player;
-
   /** 戦闘ID */
   battleID: BattleID;
-
   /** ステートヒストリー */
   stateHistory: GameState[];
-
   /** フローID */
   flowID: FlowID;
-
   /** 戦闘進捗ポーリングを実行する側か否か、trueでポーリングをする */
   isPoller: boolean;
 };

--- a/packages/backend-app/src/send-command.ts
+++ b/packages/backend-app/src/send-command.ts
@@ -9,7 +9,7 @@ import type { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import type { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parseSendCommand } from "./request/sned-command";
 import type { AcceptCommand } from "./response/accept-command";
-import type { Error } from "./response/websocket-response";
+import type { Error } from "./response/error";
 
 const AWS_REGION = process.env.AWS_REGION ?? "";
 const SERVICE = process.env.SERVICE ?? "";

--- a/packages/backend-app/src/send-command.ts
+++ b/packages/backend-app/src/send-command.ts
@@ -8,7 +8,8 @@ import { extractUserFromWebSocketAuthorizer } from "./lambda/extract-user";
 import type { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import type { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parseSendCommand } from "./request/sned-command";
-import type { AcceptCommand, Error } from "./response/websocket-response";
+import type { Error } from "./response/websocket-response";
+import type { AcceptCommand } from "./response/accept-command";
 
 const AWS_REGION = process.env.AWS_REGION ?? "";
 const SERVICE = process.env.SERVICE ?? "";

--- a/packages/backend-app/src/send-command.ts
+++ b/packages/backend-app/src/send-command.ts
@@ -8,8 +8,8 @@ import { extractUserFromWebSocketAuthorizer } from "./lambda/extract-user";
 import type { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import type { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parseSendCommand } from "./request/sned-command";
-import type { Error } from "./response/websocket-response";
 import type { AcceptCommand } from "./response/accept-command";
+import type { Error } from "./response/websocket-response";
 
 const AWS_REGION = process.env.AWS_REGION ?? "";
 const SERVICE = process.env.SERVICE ?? "";


### PR DESCRIPTION
This pull request refactors the backend WebSocket response types for improved clarity, modularity, and type safety. It removes the legacy `websocket-response.ts` aggregate type, introduces dedicated response type files, and updates imports and constants throughout the codebase to use the new structure. Additionally, it centralizes the `WebsocketResponse` type definition in an `index.ts` file to provide a single source of truth for all WebSocket responses.

**Type System Refactoring and Modularization**

* Removed the legacy `websocket-response.ts` type, replacing it with individual response type modules (e.g., `battle-start.ts`, `error.ts`, `pong.ts`), each exporting their own types and constants for use throughout the backend. [[1]](diffhunk://#diff-625fd5714def7b27e390b17dca931874ba6d28f2dbd7fad111f91b0958e7d7ccL1-R22) [[2]](diffhunk://#diff-5c3ce37da9aeb129f9830b4c9b23b3efe87098b73f924684f5ec1c8c024a31afR1-R12) [[3]](diffhunk://#diff-7989b17c9f6ee3935dc7951f07dacc5438725f304fd57ae08ed80371bf5b7edfR1-R6) [[4]](diffhunk://#diff-7781c3fcbae9e8a12d93ced303c7291515be8bc0bf6ee63abbd97b3beebd8023L1-L7) [[5]](diffhunk://#diff-efe1835945064c47fc20c64e20abfcc4ad2fc97118a825a14ce96d618625e1cdL1-R7) [[6]](diffhunk://#diff-5a572ed2298eba61d0f085f81853abc00c41b24eac01012a9bb85051fea7f2c5R1-R4) [[7]](diffhunk://#diff-043bf07bdd6b0302e80ee0e908ec1460f417570f2b2ceaf15f151909c0350d52R1-R12) [[8]](diffhunk://#diff-f0756893a5d23f2e9f20bf96d8cf577107430105267a2bb96c4bfbe1575b06f1R1-R8) [[9]](diffhunk://#diff-94eda4062d630ed134ef404770c1d394add452efc3f5a56b309c7aa0e0e99909R1-R8) [[10]](diffhunk://#diff-91278a0d8960eef2eac1aba9d622994cf6fe4fb32c7ac6529f147a3b9dc358f6R1-R4) Fffd36807L1)

* Added a new `index.ts` in the `response` directory that aggregates all individual response types into a unified `WebsocketResponse` union type, now used as the central type for WebSocket responses.

**Import and Usage Updates**

* Updated all relevant imports in API handler files to use the new, modular response types and constants instead of the old aggregate type and constants (e.g., `INVALID_REQUEST_BODY_ERROR`, `CLOUD_NOT_PRIVATE_MATCH_MAKE`, `NOT_READY_BATTLE_PROGRESS`). [[1]](diffhunk://#diff-5a60ed810e3b90b9142164fb2a01748324bb567a62565d7eeebda752e39e5132L4-R4) [[2]](diffhunk://#diff-f4dec909c7b01fd422fd8e235f62d8194411efdc2b0c506d2797cab3c6addef4L24-R25) [[3]](diffhunk://#diff-f4dec909c7b01fd422fd8e235f62d8194411efdc2b0c506d2797cab3c6addef4L74-R74) [[4]](diffhunk://#diff-f4dec909c7b01fd422fd8e235f62d8194411efdc2b0c506d2797cab3c6addef4L89-R89) [[5]](diffhunk://#diff-989fb8f7bdabd38129e45768b897ad032e6f4a14bc90ac80ff25c3aa8cf2138eL14-R14) [[6]](diffhunk://#diff-82f83725d199cdb6290359a45c2efc0794f3645223af2d12b7b7d5d86b83d89eL12-R13) [[7]](diffhunk://#diff-36d20105aa4088fca75830f0e826155ace241aad85f093d7ea2e2f2597010a8dL13-R14) [[8]](diffhunk://#diff-5c2ec9ef38eb305f19a414003c3dde73a4b1c3fda5ca01102fe3b91bc762c24cL13-R13) [[9]](diffhunk://#diff-33f9c48f6661e22859c1f4cb8117fa0397d5c82f3061a0fe9b3b9c713198b63cL6-R6) [[10]](diffhunk://#diff-5a2a4aa5274e1ffe413b37be16139d9088dcc45706c26be53d12b6e69fe98618L19-R22) [[11]](diffhunk://#diff-5a2a4aa5274e1ffe413b37be16139d9088dcc45706c26be53d12b6e69fe98618L64-R64) [[12]](diffhunk://#diff-5a2a4aa5274e1ffe413b37be16139d9088dcc45706c26be53d12b6e69fe98618L79-R79) [[13]](diffhunk://#diff-5a2a4aa5274e1ffe413b37be16139d9088dcc45706c26be53d12b6e69fe98618L88-R88) [[14]](diffhunk://#diff-5a2a4aa5274e1ffe413b37be16139d9088dcc45706c26be53d12b6e69fe98618L105-R105)

**Constant and Type Definition Improvements**

* Standardized the definition and export of commonly used constants (e.g., `INVALID_REQUEST_BODY_ERROR`, `NOT_READY_BATTLE_PROGRESS`, `CLOUD_NOT_PRIVATE_MATCH_MAKE`, `REJECT_PRIVATE_MATCH_ENTRY`) to improve consistency and reduce duplication. [[1]](diffhunk://#diff-5c3ce37da9aeb129f9830b4c9b23b3efe87098b73f924684f5ec1c8c024a31afR1-R12) [[2]](diffhunk://#diff-efe1835945064c47fc20c64e20abfcc4ad2fc97118a825a14ce96d618625e1cdL1-R7) Fffd36807L1, [[3]](diffhunk://#diff-5a2a4aa5274e1ffe413b37be16139d9088dcc45706c26be53d12b6e69fe98618L19-R22)

**File Renaming and Cleanup**

* Renamed files for clarity and consistency (e.g., `create-battle-start.ts` → `battle-start.ts`), and removed obsolete files such as `invalid-request-body-error.ts`. [[1]](diffhunk://#diff-625fd5714def7b27e390b17dca931874ba6d28f2dbd7fad111f91b0958e7d7ccL1-R22) [[2]](diffhunk://#diff-7781c3fcbae9e8a12d93ced303c7291515be8bc0bf6ee63abbd97b3beebd8023L1-L7)

**New Response Types**

* Introduced new response types for specific events, such as `AcceptCommand`, `BattleEnd`, `BattleProgressed`, `CreatedPrivateMatchRoom`, `EnteredCasualMatch`, and `Pong`, each with clear type definitions and documentation. [[1]](diffhunk://#diff-5a572ed2298eba61d0f085f81853abc00c41b24eac01012a9bb85051fea7f2c5R1-R4) [[2]](diffhunk://#diff-f0756893a5d23f2e9f20bf96d8cf577107430105267a2bb96c4bfbe1575b06f1R1-R8) [[3]](diffhunk://#diff-043bf07bdd6b0302e80ee0e908ec1460f417570f2b2ceaf15f151909c0350d52R1-R12) [[4]](diffhunk://#diff-94eda4062d630ed134ef404770c1d394add452efc3f5a56b309c7aa0e0e99909R1-R8) [[5]](diffhunk://#diff-91278a0d8960eef2eac1aba9d622994cf6fe4fb32c7ac6529f147a3b9dc358f6R1-R4) [[6]](diffhunk://#diff-7989b17c9f6ee3935dc7951f07dacc5438725f304fd57ae08ed80371bf5b7edfR1-R6)