### PR TITLE
eslintの非推奨設定を新しいもので置き換えた

### DIFF
--- a/packages/aws-vpc/eslint.config.mjs
+++ b/packages/aws-vpc/eslint.config.mjs
@@ -1,9 +1,10 @@
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
 import jest from "eslint-plugin-jest";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: [
       "node_modules/*",

--- a/packages/backend-app/eslint.config.mjs
+++ b/packages/backend-app/eslint.config.mjs
@@ -1,9 +1,10 @@
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
 import jest from "eslint-plugin-jest";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: [
       "node_modules/*",

--- a/packages/backend-ecs/eslint.config.mjs
+++ b/packages/backend-ecs/eslint.config.mjs
@@ -1,9 +1,10 @@
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
 import jest from "eslint-plugin-jest";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: [
       "node_modules/*",

--- a/packages/browser-sdk/eslint.config.mjs
+++ b/packages/browser-sdk/eslint.config.mjs
@@ -1,9 +1,10 @@
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
 import jest from "eslint-plugin-jest";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: ["node_modules/*", "coverage/*", "lib/*"],
   },

--- a/packages/offline-backend-app/eslint.config.mjs
+++ b/packages/offline-backend-app/eslint.config.mjs
@@ -1,9 +1,10 @@
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
 import jest from "eslint-plugin-jest";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: [
       "node_modules/*",
@@ -11,7 +12,6 @@ export default tseslint.config(
       ".webpack/*",
       ".serverless/*",
       "**/*.js",
-      "**/*.mjs",
     ],
   },
   {

--- a/packages/offline-browser-sdk/eslint.config.mjs
+++ b/packages/offline-browser-sdk/eslint.config.mjs
@@ -1,8 +1,9 @@
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: [
       "node_modules/*",
@@ -10,7 +11,6 @@ export default tseslint.config(
       "lib/*",
       "build/*",
       "**/*.js",
-      "**/*.mjs",
     ],
   },
   {

--- a/packages/offline-browser-sdk/eslint.config.mjs
+++ b/packages/offline-browser-sdk/eslint.config.mjs
@@ -5,13 +5,7 @@ import tseslint from "typescript-eslint";
 
 export default defineConfig(
   {
-    ignores: [
-      "node_modules/*",
-      "coverage/*",
-      "lib/*",
-      "build/*",
-      "**/*.js",
-    ],
+    ignores: ["node_modules/*", "coverage/*", "lib/*", "build/*", "**/*.js"],
   },
   {
     files: ["**/*.ts"],

--- a/packages/offline-stub/eslint.config.mjs
+++ b/packages/offline-stub/eslint.config.mjs
@@ -1,8 +1,9 @@
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: [
       "node_modules/*",
@@ -10,7 +11,6 @@ export default tseslint.config(
       "lib/*",
       "build/*",
       "**/*.js",
-      "**/*.mjs",
     ],
   },
   {

--- a/packages/offline-stub/eslint.config.mjs
+++ b/packages/offline-stub/eslint.config.mjs
@@ -5,13 +5,7 @@ import tseslint from "typescript-eslint";
 
 export default defineConfig(
   {
-    ignores: [
-      "node_modules/*",
-      "coverage/*",
-      "lib/*",
-      "build/*",
-      "**/*.js",
-    ],
+    ignores: ["node_modules/*", "coverage/*", "lib/*", "build/*", "**/*.js"],
   },
   {
     files: ["**/*.ts"],

--- a/packages/serverless-stub/eslint.config.mjs
+++ b/packages/serverless-stub/eslint.config.mjs
@@ -1,9 +1,10 @@
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
 import jest from "eslint-plugin-jest";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: ["node_modules/*", "coverage/*", "build/*", "webpack.config.js"],
   },

--- a/packages/ws-signal/eslint.config.mjs
+++ b/packages/ws-signal/eslint.config.mjs
@@ -1,8 +1,9 @@
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: ["node_modules/*", ".serverless/*"],
   },


### PR DESCRIPTION
This pull request updates the ESLint configuration files across multiple packages to use the new `defineConfig` helper from `eslint/config` instead of the older `tseslint.config` approach. This change modernizes the configuration setup and aligns it with current ESLint best practices. Additionally, some packages update their ignore patterns to remove unnecessary exclusions.

**ESLint configuration modernization:**

* All `eslint.config.mjs` files now import and use `defineConfig` from `eslint/config` to define their configuration, replacing the previous usage of `tseslint.config`. [[1]](diffhunk://#diff-ad898aa4f6513a8258d1025bf830bf107ea6b53a9836915a56958f9cbec01d91R2-R7) [[2]](diffhunk://#diff-bf740d64085ada6fa41d2239b04565f288ebe15d1d2061f6690d0522f9e971ffR2-R7) [[3]](diffhunk://#diff-c2e035ad1d8100fd95a9d992cc318f579d0d35fcea965b0fc3b29d764b532ddcR2-R7) [[4]](diffhunk://#diff-f213f0e4d7382b7629a0088201a94d5457edd32e7cfb0fe6f8ff85240d146a10R2-L14) [[5]](diffhunk://#diff-f984a2e1cba0c5cc00691a3479dd2269946cbe9e442d086db2c41bb3c8894e03R2-L13) [[6]](diffhunk://#diff-1474ec0f4b7db5c60a82cb2b8daf3e8c34981bac3cd657378a8e5d9ed96e29f1R2-R7) [[7]](diffhunk://#diff-a902ff41abbc7d85065d6c5c473c0591b2c61aa6c7bf0a11b21bb884868ed85aR2-R6)

**Ignore pattern updates:**

* In `offline-backend-app`, `offline-browser-sdk`, and `offline-stub` packages, the `"**/*.mjs"` pattern has been removed from the ignore list, so `.mjs` files will now be linted. [[1]](diffhunk://#diff-f213f0e4d7382b7629a0088201a94d5457edd32e7cfb0fe6f8ff85240d146a10R2-L14) [[2]](diffhunk://#diff-f984a2e1cba0c5cc00691a3479dd2269946cbe9e442d086db2c41bb3c8894e03R2-L13)