### PR TITLE
シグナリングを実装

### DIFF
--- a/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-guest-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-guest-sdk.ts
@@ -1,5 +1,7 @@
+import { waitUntilIceCandidate } from "../webrtc/wait-untilIce-candidate";
 import { connectWSSignal } from "../ws-signal/connect-ws-signal";
 import { joinRoom } from "../ws-signal/join-room";
+import { sendGuestSignal } from "../ws-signal/send-guest-signal";
 
 /** ローカルWebRTCゲスト用SDK */
 export type LocalWebRTCGuestSDK = {
@@ -33,7 +35,26 @@ class LocalWebRTCGuestSDKImpl implements LocalWebRTCGuestSDK {
       return false;
     }
 
-    return true;
+    const { sdp: hostSDP, iceCandidates: hostIceCandidates } = joinRoomAccepted;
+    const connection = new RTCPeerConnection();
+    await connection.setRemoteDescription(hostSDP);
+    await Promise.all(
+      hostIceCandidates.map((c) => connection.addIceCandidate(c)),
+    );
+    const guestSDP = await connection.createAnswer();
+    const [guestIceCandidates] = await Promise.all([
+      // icecandidateイベントはsetLocalDescriptionの後に発生するため、先に待機しておく
+      waitUntilIceCandidate(connection),
+      connection.setLocalDescription(guestSDP),
+    ]);
+    const { reservationID } = joinRoomAccepted;
+    return await sendGuestSignal({
+      websocket,
+      roomID,
+      reservationID,
+      sdp: guestSDP,
+      iceCandidates: guestIceCandidates,
+    });
   }
 }
 

--- a/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-guest-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-guest-sdk.ts
@@ -1,4 +1,5 @@
 import { connectWSSignal } from "../ws-signal/connect-ws-signal";
+import { joinRoom } from "../ws-signal/join-room";
 
 /** ローカルWebRTCゲスト用SDK */
 export type LocalWebRTCGuestSDK = {
@@ -14,11 +15,6 @@ export type LocalWebRTCGuestSDK = {
 class LocalWebRTCGuestSDKImpl implements LocalWebRTCGuestSDK {
   /** WebSocketシグナルサーバーのURL */
   #wsSignalUrl: string;
-  /**
-   * 接続中のWebSocket、接続されていない場合はnull
-   * シグナリングの時だけ接続されている想定
-   */
-  #websocket: WebSocket | null = null;
 
   /**
    * コンストラクタ
@@ -29,11 +25,14 @@ class LocalWebRTCGuestSDKImpl implements LocalWebRTCGuestSDK {
   }
 
   /** @override */
-  async joinRoom() {
-    this.#websocket = await connectWSSignal(this.#wsSignalUrl);
-    this.#websocket.close();
+  async joinRoom(roomID: string) {
+    const websocket = await connectWSSignal(this.#wsSignalUrl);
+    const joinRoomAccepted = await joinRoom({ websocket, roomID });
+    if (!joinRoomAccepted) {
+      websocket.close();
+      return false;
+    }
 
-    // TODO ロジックを作る
     return true;
   }
 }

--- a/packages/local-webrtc-browser-sdk/src/ws-signal/create-room.ts
+++ b/packages/local-webrtc-browser-sdk/src/ws-signal/create-room.ts
@@ -7,6 +7,7 @@ import { sendToWSSignal } from "./send-to-ws-signal";
 
 /**
  * ルームを生成する
+ * @param options オプション
  * @param options.websocket WebSocketコネクション
  * @param options.sdp ホストのSDP
  * @param options.iceCandidates ホストのICE候補

--- a/packages/local-webrtc-browser-sdk/src/ws-signal/join-room.ts
+++ b/packages/local-webrtc-browser-sdk/src/ws-signal/join-room.ts
@@ -1,33 +1,30 @@
 import { parseJSON } from "../json/parse";
 import { Signal } from "../webrtc/signal";
+import { JoinRoomAcceptedSchema } from "./response/join-room-accepted";
 import { JoinRoomRejectedSchema } from "./response/join-room-rejected";
-import { MatchingSchema } from "./response/matching";
 import { sendToWSSignal } from "./send-to-ws-signal";
 
 /**
  * ルームに参加する
  * @param websocket WebSocketコネクション
  * @param roomID 参加するルームのID
- * @param sdp 自身のSDP
- * @param iceCandidates 自身のICE候補
  * @return ルームへの参加に成功したらSignal、失敗したらnull
  */
 export const joinRoom = (options: {
   websocket: WebSocket;
   roomID: string;
-  sdp: RTCSessionDescriptionInit;
-  iceCandidates: RTCIceCandidateInit[];
 }): Promise<Signal | null> => {
-  const { websocket, roomID, sdp, iceCandidates } = options;
+  const { websocket, roomID } = options;
   let handler: ((event: MessageEvent) => void) | null = null;
   return new Promise<Signal | null>((resolve) => {
     handler = (event) => {
       const parsedData = parseJSON(event.data);
 
-      const parsedMatching = MatchingSchema.safeParse(parsedData);
-      if (parsedMatching.success) {
-        const matching = parsedMatching.data;
-        const { sdp, iceCandidates } = matching;
+      const parsedJoinRoomAccepted =
+        JoinRoomAcceptedSchema.safeParse(parsedData);
+      if (parsedJoinRoomAccepted.success) {
+        const joinRoomAccepted = parsedJoinRoomAccepted.data;
+        const { sdp, iceCandidates } = joinRoomAccepted;
         resolve({ sdp, iceCandidates });
         return;
       }
@@ -40,12 +37,7 @@ export const joinRoom = (options: {
       }
     };
     websocket.addEventListener("message", handler);
-    sendToWSSignal(websocket, {
-      action: "join-room",
-      roomID,
-      sdp,
-      iceCandidates,
-    });
+    sendToWSSignal(websocket, { action: "join-room", roomID });
   }).finally(() => {
     if (handler) {
       websocket.removeEventListener("message", handler);

--- a/packages/local-webrtc-browser-sdk/src/ws-signal/join-room.ts
+++ b/packages/local-webrtc-browser-sdk/src/ws-signal/join-room.ts
@@ -8,8 +8,9 @@ import { sendToWSSignal } from "./send-to-ws-signal";
 
 /**
  * ルームに参加する
- * @param websocket WebSocketコネクション
- * @param roomID 参加するルームのID
+ * @param options オプション
+ * @param options.websocket WebSocketコネクション
+ * @param options.roomID 参加するルームのID
  * @return ルームへの参加に成功したらJoinRoomAccepted、失敗したらnull
  */
 export const joinRoom = (options: {
@@ -21,7 +22,6 @@ export const joinRoom = (options: {
   return new Promise<JoinRoomAccepted | null>((resolve) => {
     handler = (event) => {
       const parsedData = parseJSON(event.data);
-
       const parsedJoinRoomAccepted =
         JoinRoomAcceptedSchema.safeParse(parsedData);
       if (parsedJoinRoomAccepted.success) {

--- a/packages/local-webrtc-browser-sdk/src/ws-signal/join-room.ts
+++ b/packages/local-webrtc-browser-sdk/src/ws-signal/join-room.ts
@@ -1,6 +1,8 @@
 import { parseJSON } from "../json/parse";
-import { Signal } from "../webrtc/signal";
-import { JoinRoomAcceptedSchema } from "./response/join-room-accepted";
+import {
+  JoinRoomAccepted,
+  JoinRoomAcceptedSchema,
+} from "./response/join-room-accepted";
 import { JoinRoomRejectedSchema } from "./response/join-room-rejected";
 import { sendToWSSignal } from "./send-to-ws-signal";
 
@@ -8,24 +10,22 @@ import { sendToWSSignal } from "./send-to-ws-signal";
  * ルームに参加する
  * @param websocket WebSocketコネクション
  * @param roomID 参加するルームのID
- * @return ルームへの参加に成功したらSignal、失敗したらnull
+ * @return ルームへの参加に成功したらJoinRoomAccepted、失敗したらnull
  */
 export const joinRoom = (options: {
   websocket: WebSocket;
   roomID: string;
-}): Promise<Signal | null> => {
+}): Promise<JoinRoomAccepted | null> => {
   const { websocket, roomID } = options;
   let handler: ((event: MessageEvent) => void) | null = null;
-  return new Promise<Signal | null>((resolve) => {
+  return new Promise<JoinRoomAccepted | null>((resolve) => {
     handler = (event) => {
       const parsedData = parseJSON(event.data);
 
       const parsedJoinRoomAccepted =
         JoinRoomAcceptedSchema.safeParse(parsedData);
       if (parsedJoinRoomAccepted.success) {
-        const joinRoomAccepted = parsedJoinRoomAccepted.data;
-        const { sdp, iceCandidates } = joinRoomAccepted;
-        resolve({ sdp, iceCandidates });
+        resolve(parsedJoinRoomAccepted.data);
         return;
       }
 

--- a/packages/local-webrtc-browser-sdk/src/ws-signal/request/index.ts
+++ b/packages/local-webrtc-browser-sdk/src/ws-signal/request/index.ts
@@ -1,5 +1,6 @@
 import { CreateRoom } from "./create-room";
 import { JoinRoom } from "./join-room";
+import { SendGuestSignal } from "./send-guest-signal";
 
 /** WebSocketシグナルサーバーへのリクエスト */
-export type WSSignalRequest = CreateRoom | JoinRoom;
+export type WSSignalRequest = CreateRoom | JoinRoom | SendGuestSignal;

--- a/packages/local-webrtc-browser-sdk/src/ws-signal/request/join-room.ts
+++ b/packages/local-webrtc-browser-sdk/src/ws-signal/request/join-room.ts
@@ -3,8 +3,4 @@ export type JoinRoom = {
   action: "join-room";
   /** ルームID */
   roomID: string;
-  /** クライアントのSDP */
-  sdp: RTCSessionDescriptionInit;
-  /** クライアントのICE候補 */
-  iceCandidates: RTCIceCandidateInit[];
 };

--- a/packages/local-webrtc-browser-sdk/src/ws-signal/request/send-guest-signal.ts
+++ b/packages/local-webrtc-browser-sdk/src/ws-signal/request/send-guest-signal.ts
@@ -1,0 +1,12 @@
+/** ゲストのシグナルを送信 */
+export type SendGuestSignal = {
+  action: "send-guest-signal";
+  /** ルームID */
+  roomID: string;
+  /** 予約ID */
+  reservationID: string;
+  /** ゲストのSDP */
+  sdp: RTCSessionDescriptionInit;
+  /** ゲストのICE候補 */
+  iceCandidates: RTCIceCandidateInit[];
+};

--- a/packages/local-webrtc-browser-sdk/src/ws-signal/response/join-room-accepted.ts
+++ b/packages/local-webrtc-browser-sdk/src/ws-signal/response/join-room-accepted.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+import { RTCIceCandidateInitSchema } from "../../webrtc/rtc-ice-candidate-init-schema";
+import { RTCSessionDescriptionInitSchema } from "../../webrtc/rtc-session-description-init-schema";
+
+/** ルーム参加承認 */
+export type JoinRoomAccepted = {
+  type: "join-room-accepted";
+  /** 予約ID */
+  reservationID: string;
+  /** ホストのSDP */
+  sdp: RTCSessionDescriptionInit;
+  /** ホストのICE候補 */
+  iceCandidates: RTCIceCandidateInit[];
+};
+
+/** JoinRoomAccepted zod スキーマ */
+export const JoinRoomAcceptedSchema = z.object({
+  type: z.literal("join-room-accepted"),
+  reservationID: z.string(),
+  sdp: RTCSessionDescriptionInitSchema,
+  iceCandidates: z.array(RTCIceCandidateInitSchema),
+});

--- a/packages/local-webrtc-browser-sdk/src/ws-signal/response/send-guest-signal-accepted.ts
+++ b/packages/local-webrtc-browser-sdk/src/ws-signal/response/send-guest-signal-accepted.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+/** ゲストのシグナル送信が承認された */
+export type SendGuestSignalAccepted = {
+  type: "send-guest-signal-accepted";
+};
+
+/** SendGuestSignalAccepted zod スキーマ */
+export const SendGuestSignalAcceptedSchema = z.object({
+  type: z.literal("send-guest-signal-accepted"),
+});

--- a/packages/local-webrtc-browser-sdk/src/ws-signal/response/send-guest-signal-rejected.ts
+++ b/packages/local-webrtc-browser-sdk/src/ws-signal/response/send-guest-signal-rejected.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+/** ゲストのシグナル送信が拒否された */
+export type SendGuestSignalRejected = {
+  type: "send-guest-signal-rejected";
+};
+
+/** SendGuestSignalRejected zod スキーマ */
+export const SendGuestSignalRejectedSchema = z.object({
+  type: z.literal("send-guest-signal-rejected"),
+});

--- a/packages/local-webrtc-browser-sdk/src/ws-signal/send-guest-signal.ts
+++ b/packages/local-webrtc-browser-sdk/src/ws-signal/send-guest-signal.ts
@@ -1,0 +1,55 @@
+import { parseJSON } from "../json/parse";
+import { SendGuestSignalAcceptedSchema } from "./response/send-guest-signal-accepted";
+import { SendGuestSignalRejectedSchema } from "./response/send-guest-signal-rejected";
+import { sendToWSSignal } from "./send-to-ws-signal";
+
+/**
+ * ゲストのシグナルを送信する
+ * @param options オプション
+ * @param options.websocket WebSocketコネクション
+ * @param options.roomID 参加するルームのID
+ * @param options.reservationID 予約ID
+ * @param options.sdp ゲストのSDP
+ * @param options.iceCandidates ゲストのICE候補
+ * @return ゲストのシグナルの送信に成功したらtrue、失敗したらfalse
+ */
+export const sendGuestSignal = (options: {
+  websocket: WebSocket;
+  roomID: string;
+  reservationID: string;
+  sdp: RTCSessionDescriptionInit;
+  iceCandidates: RTCIceCandidateInit[];
+}): Promise<boolean> => {
+  const { websocket, roomID, reservationID, sdp, iceCandidates } = options;
+  let handler: ((event: MessageEvent) => void) | null = null;
+  return new Promise<boolean>((resolve) => {
+    handler = (event) => {
+      const parsedData = parseJSON(event.data);
+      const parsedSendGuestSignalAccepted =
+        SendGuestSignalAcceptedSchema.safeParse(parsedData);
+      if (parsedSendGuestSignalAccepted.success) {
+        resolve(true);
+        return;
+      }
+
+      const parsedSendGuestSignalRejected =
+        SendGuestSignalRejectedSchema.safeParse(parsedData);
+      if (parsedSendGuestSignalRejected.success) {
+        resolve(false);
+        return;
+      }
+    };
+    websocket.addEventListener("message", handler);
+    sendToWSSignal(websocket, {
+      action: "send-guest-signal",
+      roomID,
+      reservationID,
+      sdp,
+      iceCandidates,
+    });
+  }).finally(() => {
+    if (handler) {
+      websocket.removeEventListener("message", handler);
+    }
+  });
+};

--- a/packages/local-webrtc-stub/src/index.ts
+++ b/packages/local-webrtc-stub/src/index.ts
@@ -1,4 +1,7 @@
-import { createLocalWebRTCHostSDK } from "@gbraver-burst-network/local-webrtc-browser-sdk";
+import {
+  createLocalWebRTCGuestSDK,
+  createLocalWebRTCHostSDK,
+} from "@gbraver-burst-network/local-webrtc-browser-sdk";
 
 import { GuestPlayer } from "./use-case/guest-player";
 import { HostPlayer } from "./use-case/host-player";
@@ -47,7 +50,11 @@ const getRoomIDInput = (): HTMLInputElement => {
  */
 window.onload = () => {
   const hostSDK = createLocalWebRTCHostSDK(WS_SIGNAL_SERVER_URL);
-  const useCases: UseCase[] = [new HostPlayer(hostSDK), new GuestPlayer()];
+  const guestSDK = createLocalWebRTCGuestSDK(WS_SIGNAL_SERVER_URL);
+  const useCases: UseCase[] = [
+    new HostPlayer(hostSDK),
+    new GuestPlayer(guestSDK),
+  ];
 
   const useCaseSelector = getUseCaseSelector();
   const useCaseExecuteButton = getUseCaseExecuteButton();

--- a/packages/local-webrtc-stub/src/use-case/guest-player.ts
+++ b/packages/local-webrtc-stub/src/use-case/guest-player.ts
@@ -1,7 +1,20 @@
+import { LocalWebRTCGuestSDK } from "@gbraver-burst-network/local-webrtc-browser-sdk";
+
 import { UseCase, UseCaseContext } from "./use-case";
 
 /** ゲスト側プレイヤー */
 export class GuestPlayer implements UseCase {
+  /** ローカルWebRTCゲスト用SDK */
+  #guestSDK: LocalWebRTCGuestSDK;
+
+  /**
+   * コンストラクタ
+   * @param guestSDK ローカルWebRTCゲスト用SDK
+   */
+  constructor(guestSDK: LocalWebRTCGuestSDK) {
+    this.#guestSDK = guestSDK;
+  }
+
   /** @override */
   name(): string {
     return "ゲスト側プレイヤー";
@@ -9,6 +22,9 @@ export class GuestPlayer implements UseCase {
 
   /** @override */
   async execute(context: UseCaseContext): Promise<void> {
-    console.log("ゲスト側プレイヤーを実行", context);
+    const { roomID } = context;
+    console.log("start join room, roomID:", roomID);
+    const isJoined = await this.#guestSDK.joinRoom(roomID);
+    console.log("join room result:", isJoined);
   }
 }


### PR DESCRIPTION
This pull request significantly refactors and completes the WebRTC guest join flow in the local WebRTC browser SDK. It introduces a two-step signaling process for guests joining a room, adds new types and schemas for signaling, and updates the stub and use case implementations to utilize the new guest SDK. The changes improve type safety, separation of concerns, and make the guest connection process more robust and explicit.

**WebRTC Guest Join Flow Refactor and Feature Completion:**

*Guest SDK and Join Flow:*
- The `LocalWebRTCGuestSDK` and its implementation are updated to use a two-step process for joining a room: first sending a join request, then sending guest signaling data after receiving host information. The join process now returns a boolean indicating success or failure. (`local-webrtc-guest-sdk.ts`, `join-room.ts`, `send-guest-signal.ts`, [[1]](diffhunk://#diff-bb3e1dbc5d7f5792dfb2e81a80d0b81cb1ce885efe93d298d58d32941b5a8131R1-R4) [[2]](diffhunk://#diff-bb3e1dbc5d7f5792dfb2e81a80d0b81cb1ce885efe93d298d58d32941b5a8131L32-R57) [[3]](diffhunk://#diff-aeb03e26a0b4ce06b2d4f38b2a5782909838527f72a7d58a4de4895c20dccacaL2-R28) [[4]](diffhunk://#diff-42f6608bf4025ffb35ad7ba85ae414491db725246b818edda484fbba286a6a88R1-R55)

*Signaling Protocol and Types:*
- New request and response types and zod schemas are introduced for guest signaling: `SendGuestSignal`, `JoinRoomAccepted`, `SendGuestSignalAccepted`, and `SendGuestSignalRejected`. The join request no longer includes the guest's SDP/ICE; these are now sent separately after room acceptance. (`request/send-guest-signal.ts`, `request/join-room.ts`, `response/join-room-accepted.ts`, `response/send-guest-signal-accepted.ts`, `response/send-guest-signal-rejected.ts`, [[1]](diffhunk://#diff-5c305a22393f5005484f28ad83052926801a07ab63411c5c426994ecb395ef44R1-R12) [[2]](diffhunk://#diff-7a32d20830f7a27a2b90c500db4ef922a4272e6db9b3fb43be854dfff1624a9aL6-L9) [[3]](diffhunk://#diff-664785a73f528182c0d9c635485b4f25407a879be67f83951363f38485bef376R1-R23) [[4]](diffhunk://#diff-d7ca99435bd9ae61cb7c008fd6b79230a5d73408f364f3b2b652e3c8ec06039fR1-R11) [[5]](diffhunk://#diff-bded1cde44aa2fa94485721318d3776bc2d1db7497961b53343aa642f13fe98dR1-R11)

*Stub and Use Case Integration:*
- The local WebRTC stub now creates and injects the guest SDK into the `GuestPlayer` use case, which uses the new join flow and logs the result. (`local-webrtc-stub/src/index.ts`, `local-webrtc-stub/src/use-case/guest-player.ts`, [[1]](diffhunk://#diff-d20d21b21985a6e713d0b66d0a2d758d316bc011bf7be43271d8645302119772L1-R4) [[2]](diffhunk://#diff-d20d21b21985a6e713d0b66d0a2d758d316bc011bf7be43271d8645302119772L50-R57) [[3]](diffhunk://#diff-8065782899ce6199a4392e7559a3091066333ef30e70d4f2d6d865d45a88d328R1-R28)

*Internal Cleanup and Documentation:*
- Removes unused fields and updates documentation/comments to reflect the new join process and method signatures. (`local-webrtc-guest-sdk.ts`, [[1]](diffhunk://#diff-bb3e1dbc5d7f5792dfb2e81a80d0b81cb1ce885efe93d298d58d32941b5a8131L17-L21) [[2]](diffhunk://#diff-b77962bf46efccf2aefa3f5b66dcd286545d7599925beb1ad4edb7c9fe7d2d2fR10)

*Type Aggregation:*
- Updates the union type for WebSocket requests to include the new `SendGuestSignal` type. (`request/index.ts`, [packages/local-webrtc-browser-sdk/src/ws-signal/request/index.tsR3-R6](diffhunk://#diff-4b06b2e9c0e7da1ebcdbb6d436ecd77f6e871aa1a893d547dfb02187c5004259R3-R6))