### PR TITLE
fix: 空のroomIDに対するエラーハンドリングを追加

### DIFF
--- a/packages/ws-signal/src/join-room.ts
+++ b/packages/ws-signal/src/join-room.ts
@@ -56,6 +56,13 @@ export async function joinRoom(
 
   const joinRoomRequest = parsedJoinRoom.data;
   const { roomID } = joinRoomRequest;
+  if (roomID === "") {
+    await notifier.notifyToClient(guestConnectionId, {
+      type: "join-room-rejected",
+    });
+    return { statusCode: 200, body: "join room rejected" };
+  }
+
   const updatedRoom = await dynamoRooms.updateToAwaitingGuestSignal(roomID);
   if (!updatedRoom) {
     await notifier.notifyToClient(guestConnectionId, {


### PR DESCRIPTION
This pull request adds input validation to the `joinRoom` function to prevent users from joining a room with an empty `roomID`. If an empty `roomID` is detected, the client is notified that the join request was rejected and the function exits early.

Input validation and error handling:

* Added a check in `joinRoom` (in `join-room.ts`) to reject join requests with an empty `roomID`, notifying the client and returning early.