### PR TITLE
ブラウザSDKにcoturn接続を追加した

### DIFF
--- a/packages/local-webrtc-browser-sdk/src/sdk/create-rtc-peer-connection.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/create-rtc-peer-connection.ts
@@ -1,0 +1,35 @@
+import { issueCoturnCredential } from "../webrtc-helper/issue-coturn-credential";
+
+/**
+ * RTPeerConnectionを作成する
+ * @param options オプション
+ * @param options.webRTCHelperApiURL WebRTCヘルパーAPIのURL
+ * @param options.coturnDomainName coturnサーバーのドメイン名
+ * @returns 作成したRTCPeerConnection
+ */
+export const createRTCPeerConnection = async (options: {
+  /** WebRTCヘルパーAPIのURL */
+  webRTCHelperApiURL: string;
+  /** coturnサーバーのドメイン名 */
+  coturnDomainName: string;
+}): Promise<RTCPeerConnection> => {
+  const { webRTCHelperApiURL, coturnDomainName } = options;
+  const { username, password: credential } =
+    await issueCoturnCredential(webRTCHelperApiURL);
+  return new RTCPeerConnection({
+    iceServers: [
+      {
+        urls: [`stun:${coturnDomainName}:3478`],
+      },
+      {
+        urls: [
+          `turn:${coturnDomainName}:3478?transport=udp`,
+          `turn:${coturnDomainName}:3478?transport=tcp`,
+          `turns:${coturnDomainName}:5349?transport=tcp`,
+        ],
+        username,
+        credential,
+      },
+    ],
+  });
+};

--- a/packages/local-webrtc-browser-sdk/src/sdk/create-rtc-peer-connection.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/create-rtc-peer-connection.ts
@@ -1,7 +1,7 @@
 import { issueCoturnCredential } from "../webrtc-helper/issue-coturn-credential";
 
 /**
- * RTPeerConnectionを作成する
+ * RTCPeerConnectionを作成する
  * @param options オプション
  * @param options.webRTCHelperApiURL WebRTCヘルパーAPIのURL
  * @param options.coturnDomainName coturnサーバーのドメイン名

--- a/packages/local-webrtc-browser-sdk/src/sdk/guest-battle-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/guest-battle-sdk.ts
@@ -45,7 +45,7 @@ export class GuestBattleSDK implements BattleSDK {
   /** @override */
   async progress(command: Command): Promise<GameState[]> {
     const dataChannel =
-      await this.#webRTCConnection.getOrCreateConnection().dataChannel;
+      await this.#webRTCConnection.getOrCreateConnection().dataChannelPromise;
     const battleProgressedPromise = receiveBattleProgressed(dataChannel);
     sendGuestMessage(dataChannel, {
       type: "send-command",

--- a/packages/local-webrtc-browser-sdk/src/sdk/guest-webrtc-connection-manager.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/guest-webrtc-connection-manager.ts
@@ -17,6 +17,14 @@ type Disconnected = {
 /** コネクションの状態 */
 type ConnectionState = Connected | Disconnected;
 
+/** GuestWebRTCConnectionManagerコンストラクタのオプション */
+export type GuestWebRTCConnectionManagerOptions = {
+  /** WebRTCヘルパーAPIのURL */
+  webRTCHelperApiURL: string;
+  /** coturnサーバーのドメイン名 */
+  coturnDomainName: string;
+};
+
 /** ゲストのWebRTCコネクション管理 */
 export class GuestWebRTCConnectionManager {
   /** コネクションの状態 */
@@ -27,16 +35,9 @@ export class GuestWebRTCConnectionManager {
   #coturnDomainName: string;
 
   /** コンストラクタ
-   * @param options コンストラクタのオプション
-   * @param options.webRTCHelperApiURL WebRTCヘルパーAPIのURL
-   * @param options.coturnDomainName coturnサーバーのドメイン名
+   * @param options コンストラクタのオプション名
    */
-  constructor(options: {
-    /** WebRTCヘルパーAPIのURL */
-    webRTCHelperApiURL: string;
-    /** coturnサーバーのドメイン名 */
-    coturnDomainName: string;
-  }) {
+  constructor(options: GuestWebRTCConnectionManagerOptions) {
     this.#webRTCHelperApiURL = options.webRTCHelperApiURL;
     this.#coturnDomainName = options.coturnDomainName;
   }

--- a/packages/local-webrtc-browser-sdk/src/sdk/guest-webrtc-connection-manager.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/guest-webrtc-connection-manager.ts
@@ -36,7 +36,7 @@ export class GuestWebRTCConnectionManager {
   #coturnDomainName: string;
 
   /** コンストラクタ
-   * @param options コンストラクタのオプション名
+   * @param options オプション
    */
   constructor(options: GuestWebRTCConnectionManagerOptions) {
     this.#webRTCHelperApiURL = options.webRTCHelperApiURL;

--- a/packages/local-webrtc-browser-sdk/src/sdk/guest-webrtc-connection-manager.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/guest-webrtc-connection-manager.ts
@@ -1,12 +1,13 @@
 import { waitUntilDataChannel } from "../webrtc/guest/wait-until-data-channel";
+import { createRTCPeerConnection } from "./create-rtc-peer-connection";
 
 /** 接続中 */
 type Connected = {
   type: "connected";
-  /** WebRTCコネクション */
-  connection: RTCPeerConnection;
-  /** データチャンネル、開通までラグあるためPromiseで保持 */
-  dataChannel: Promise<RTCDataChannel>;
+  /** WebRTCコネクションPromise */
+  connectionPromise: Promise<RTCPeerConnection>;
+  /** データチャンネルPromise */
+  dataChannelPromise: Promise<RTCDataChannel>;
 };
 
 /** 切断中 */
@@ -49,17 +50,22 @@ export class GuestWebRTCConnectionManager {
    */
   getOrCreateConnection(): {
     /** コネクション */
-    connection: RTCPeerConnection;
+    connectionPromise: Promise<RTCPeerConnection>;
     /** データチャンネル */
-    dataChannel: Promise<RTCDataChannel>;
+    dataChannelPromise: Promise<RTCDataChannel>;
   } {
     if (this.#connectionState.type === "disconnected") {
-      const connection = new RTCPeerConnection();
-      const dataChannel = waitUntilDataChannel(connection);
+      const connectionPromise = createRTCPeerConnection({
+        webRTCHelperApiURL: this.#webRTCHelperApiURL,
+        coturnDomainName: this.#coturnDomainName,
+      });
+      const dataChannelPromise = connectionPromise.then((connection) =>
+        waitUntilDataChannel(connection),
+      );
       this.#connectionState = {
         type: "connected",
-        connection,
-        dataChannel,
+        connectionPromise,
+        dataChannelPromise,
       };
     }
 
@@ -71,8 +77,12 @@ export class GuestWebRTCConnectionManager {
    */
   disconnect() {
     if (this.#connectionState.type === "connected") {
-      this.#connectionState.connection.close();
-      this.#connectionState.dataChannel.then((channel) => channel.close());
+      this.#connectionState.connectionPromise.then((connection) =>
+        connection.close(),
+      );
+      this.#connectionState.dataChannelPromise.then((channel) =>
+        channel.close(),
+      );
     }
     this.#connectionState = { type: "disconnected" };
   }

--- a/packages/local-webrtc-browser-sdk/src/sdk/guest-webrtc-connection-manager.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/guest-webrtc-connection-manager.ts
@@ -21,6 +21,25 @@ type ConnectionState = Connected | Disconnected;
 export class GuestWebRTCConnectionManager {
   /** コネクションの状態 */
   #connectionState: ConnectionState = { type: "disconnected" };
+  /** WebRTCヘルパーAPIのURL */
+  #webRTCHelperApiURL: string;
+  /** coturnサーバーのドメイン名 */
+  #coturnDomainName: string;
+
+  /** コンストラクタ
+   * @param options コンストラクタのオプション
+   * @param options.webRTCHelperApiURL WebRTCヘルパーAPIのURL
+   * @param options.coturnDomainName coturnサーバーのドメイン名
+   */
+  constructor(options: {
+    /** WebRTCヘルパーAPIのURL */
+    webRTCHelperApiURL: string;
+    /** coturnサーバーのドメイン名 */
+    coturnDomainName: string;
+  }) {
+    this.#webRTCHelperApiURL = options.webRTCHelperApiURL;
+    this.#coturnDomainName = options.coturnDomainName;
+  }
 
   /**
    * コネクションを取得する。

--- a/packages/local-webrtc-browser-sdk/src/sdk/host-battle-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/host-battle-sdk.ts
@@ -72,10 +72,9 @@ export class HostBattleSDK implements BattleSDK {
 
     this.flowID = nanoid();
     this.#webRTCConnection = options.webRTCConnection;
-    this.#sendCommandPromise = receiveSendCommand(
-      this.#webRTCConnection.getOrCreateConnection().dataChannel,
-      this.flowID,
-    );
+    this.#sendCommandPromise = this.#webRTCConnection
+      .getOrCreateConnection()
+      .then(({ dataChannel }) => receiveSendCommand(dataChannel, this.flowID));
   }
 
   /** @override */
@@ -89,18 +88,14 @@ export class HostBattleSDK implements BattleSDK {
     const update = this.#core.progress([hostCommand, guestCommand]);
 
     this.flowID = nanoid();
-    this.#sendCommandPromise = receiveSendCommand(
-      this.#webRTCConnection.getOrCreateConnection().dataChannel,
-      this.flowID,
-    );
-    sendHostMessage(
-      this.#webRTCConnection.getOrCreateConnection().dataChannel,
-      {
-        type: "battle-progressed",
-        flowID: this.flowID,
-        update,
-      },
-    );
+    const { dataChannel } =
+      await this.#webRTCConnection.getOrCreateConnection();
+    this.#sendCommandPromise = receiveSendCommand(dataChannel, this.flowID);
+    sendHostMessage(dataChannel, {
+      type: "battle-progressed",
+      flowID: this.flowID,
+      update,
+    });
     return update;
   }
 

--- a/packages/local-webrtc-browser-sdk/src/sdk/host-battle-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/host-battle-sdk.ts
@@ -74,7 +74,9 @@ export class HostBattleSDK implements BattleSDK {
     this.#webRTCConnection = options.webRTCConnection;
     this.#sendCommandPromise = this.#webRTCConnection
       .getOrCreateConnection()
-      .then(({ dataChannel }) => receiveSendCommand(dataChannel, this.flowID));
+      .dataChannelPromise.then((dataChannel) =>
+        receiveSendCommand(dataChannel, this.flowID),
+      );
   }
 
   /** @override */
@@ -88,8 +90,8 @@ export class HostBattleSDK implements BattleSDK {
     const update = this.#core.progress([hostCommand, guestCommand]);
 
     this.flowID = nanoid();
-    const { dataChannel } =
-      await this.#webRTCConnection.getOrCreateConnection();
+    const dataChannel =
+      await this.#webRTCConnection.getOrCreateConnection().dataChannelPromise;
     this.#sendCommandPromise = receiveSendCommand(dataChannel, this.flowID);
     sendHostMessage(dataChannel, {
       type: "battle-progressed",

--- a/packages/local-webrtc-browser-sdk/src/sdk/host-webrtc-connection-manager.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/host-webrtc-connection-manager.ts
@@ -19,6 +19,26 @@ type ConnectionState = Connected | Disconnected;
 export class HostWebRTCConnectionManager {
   /** コネクションの状態 */
   #connectionState: ConnectionState = { type: "disconnected" };
+  /** WebRTCヘルパーAPIのURL */
+  #webRTCHelperApiURL: string;
+  /** coturnサーバーのドメイン名 */
+  #coturnDomainName: string;
+
+  /**
+   * コンストラクタ
+   * @param options オプション
+   * @param options.webRTCHelperApiURL WebRTCヘルパーAPIのURL
+   * @param options.coturnDomainName coturnサーバーのドメイン名
+   */
+  constructor(options: {
+    /** WebRTCヘルパーAPIのURL */
+    webRTCHelperApiURL: string;
+    /** coturnサーバーのドメイン名 */
+    coturnDomainName: string;
+  }) {
+    this.#webRTCHelperApiURL = options.webRTCHelperApiURL;
+    this.#coturnDomainName = options.coturnDomainName;
+  }
 
   /**
    * コネクションを取得する。

--- a/packages/local-webrtc-browser-sdk/src/sdk/host-webrtc-connection-manager.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/host-webrtc-connection-manager.ts
@@ -1,9 +1,9 @@
-import { issueCoturnCredential } from "../webrtc-helper/issue-coturn-credential";
+import { createRTCPeerConnection } from "./create-rtc-peer-connection";
 
 /** 接続中 */
 type Connected = {
   type: "connected";
-  /** 
+  /**
    * コネクションPromise
    * コネクションの重複作成を防ぐために、コネクションとデータチャンネルのセットをPromiseで保持する
    */
@@ -91,24 +91,9 @@ export class HostWebRTCConnectionManager {
    * @returns コネクションPromise
    */
   async #createConnectionPromise() {
-    const { username, password: credential } = await issueCoturnCredential(
-      this.#webRTCHelperApiURL,
-    );
-    const connection = new RTCPeerConnection({
-      iceServers: [
-        {
-          urls: [`stun:${this.#coturnDomainName}:3478`],
-        },
-        {
-          urls: [
-            `turn:${this.#coturnDomainName}:3478?transport=udp`,
-            `turn:${this.#coturnDomainName}:3478?transport=tcp`,
-            `turns:${this.#coturnDomainName}:5349?transport=tcp`,
-          ],
-          username,
-          credential,
-        },
-      ],
+    const connection = await createRTCPeerConnection({
+      webRTCHelperApiURL: this.#webRTCHelperApiURL,
+      coturnDomainName: this.#coturnDomainName,
     });
     const dataChannel = connection.createDataChannel("sendDataChannel");
     return { connection, dataChannel };

--- a/packages/local-webrtc-browser-sdk/src/sdk/host-webrtc-connection-manager.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/host-webrtc-connection-manager.ts
@@ -1,3 +1,5 @@
+import { issueCoturnCredential } from "../webrtc-helper/issue-coturn-credential";
+
 /** 接続中 */
 type Connected = {
   type: "connected";
@@ -46,14 +48,32 @@ export class HostWebRTCConnectionManager {
    * コネクションが存在しない場合は新たに作成する。
    * @returns 取得したコネクションとデータチャンネル
    */
-  getOrCreateConnection(): {
+  async getOrCreateConnection(): Promise<{
     /** コネクション */
     connection: RTCPeerConnection;
     /** データチャンネル */
     dataChannel: RTCDataChannel;
-  } {
+  }> {
     if (this.#connectionState.type === "disconnected") {
-      const connection = new RTCPeerConnection();
+      const { username, password: credential } = await issueCoturnCredential(
+        this.#webRTCHelperApiURL,
+      );
+      const connection = new RTCPeerConnection({
+        iceServers: [
+          {
+            urls: [`stun:${this.#coturnDomainName}:3478`],
+          },
+          {
+            urls: [
+              `turn:${this.#coturnDomainName}:3478?transport=udp`,
+              `turn:${this.#coturnDomainName}:3478?transport=tcp`,
+              `turns:${this.#coturnDomainName}:5349?transport=tcp`,
+            ],
+            username,
+            credential,
+          },
+        ],
+      });
       const dataChannel = connection.createDataChannel("sendDataChannel");
       this.#connectionState = {
         type: "connected",

--- a/packages/local-webrtc-browser-sdk/src/sdk/host-webrtc-connection-manager.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/host-webrtc-connection-manager.ts
@@ -3,16 +3,10 @@ import { createRTCPeerConnection } from "./create-rtc-peer-connection";
 /** 接続中 */
 type Connected = {
   type: "connected";
-  /**
-   * コネクションPromise
-   * コネクションの重複作成を防ぐために、コネクションとデータチャンネルのセットをPromiseで保持する
-   */
-  connectionPromise: Promise<{
-    /** WebRTCコネクション */
-    connection: RTCPeerConnection;
-    /** データチャンネル */
-    dataChannel: RTCDataChannel;
-  }>;
+  /** WebRTCコネクションのPromise */
+  connectionPromise: Promise<RTCPeerConnection>;
+  /** データチャンネルのPromise */
+  dataChannelPromise: Promise<RTCDataChannel>;
 };
 
 /** 切断中 */
@@ -52,23 +46,30 @@ export class HostWebRTCConnectionManager {
   /**
    * コネクションを取得する。
    * コネクションが存在しない場合は新たに作成する。
-   * @returns 取得したコネクションとデータチャンネル
+   * @returns 生成したコネクション
    */
-  async getOrCreateConnection(): Promise<{
-    /** コネクション */
-    connection: RTCPeerConnection;
-    /** データチャンネル */
-    dataChannel: RTCDataChannel;
-  }> {
+  getOrCreateConnection(): {
+    /** コネクションのPromise */
+    connectionPromise: Promise<RTCPeerConnection>;
+    /** データチャンネルのPromise */
+    dataChannelPromise: Promise<RTCDataChannel>;
+  } {
     if (this.#connectionState.type === "disconnected") {
-      const connectionPromise = this.#createConnectionPromise();
+      const connectionPromise = createRTCPeerConnection({
+        webRTCHelperApiURL: this.#webRTCHelperApiURL,
+        coturnDomainName: this.#coturnDomainName,
+      });
+      const dataChannelPromise = connectionPromise.then((connection) =>
+        connection.createDataChannel("sendDataChannel"),
+      );
       this.#connectionState = {
         type: "connected",
         connectionPromise,
+        dataChannelPromise,
       };
     }
 
-    return await this.#connectionState.connectionPromise;
+    return this.#connectionState;
   }
 
   /**
@@ -76,26 +77,13 @@ export class HostWebRTCConnectionManager {
    */
   disconnect() {
     if (this.#connectionState.type === "connected") {
-      this.#connectionState.connectionPromise.then(
-        ({ connection, dataChannel }) => {
-          connection.close();
-          dataChannel.close();
-        },
-      );
+      this.#connectionState.connectionPromise.then((connection) => {
+        connection.close();
+      });
+      this.#connectionState.dataChannelPromise.then((dataChannel) => {
+        dataChannel.close();
+      });
     }
     this.#connectionState = { type: "disconnected" };
-  }
-
-  /**
-   * コネクションPromiseを生成する
-   * @returns コネクションPromise
-   */
-  async #createConnectionPromise() {
-    const connection = await createRTCPeerConnection({
-      webRTCHelperApiURL: this.#webRTCHelperApiURL,
-      coturnDomainName: this.#coturnDomainName,
-    });
-    const dataChannel = connection.createDataChannel("sendDataChannel");
-    return { connection, dataChannel };
   }
 }

--- a/packages/local-webrtc-browser-sdk/src/sdk/host-webrtc-connection-manager.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/host-webrtc-connection-manager.ts
@@ -15,6 +15,14 @@ type Disconnected = {
 /** コネクションの状態 */
 type ConnectionState = Connected | Disconnected;
 
+/** HostWebRTCConnectionManagerコンストラクタのオプション */
+export type HostWebRTCConnectionManagerOptions = {
+  /** WebRTCヘルパーAPIのURL */
+  webRTCHelperApiURL: string;
+  /** coturnサーバーのドメイン名 */
+  coturnDomainName: string;
+};
+
 /** ホストのWebRTCコネクション管理 */
 export class HostWebRTCConnectionManager {
   /** コネクションの状態 */
@@ -27,15 +35,8 @@ export class HostWebRTCConnectionManager {
   /**
    * コンストラクタ
    * @param options オプション
-   * @param options.webRTCHelperApiURL WebRTCヘルパーAPIのURL
-   * @param options.coturnDomainName coturnサーバーのドメイン名
    */
-  constructor(options: {
-    /** WebRTCヘルパーAPIのURL */
-    webRTCHelperApiURL: string;
-    /** coturnサーバーのドメイン名 */
-    coturnDomainName: string;
-  }) {
+  constructor(options: HostWebRTCConnectionManagerOptions) {
     this.#webRTCHelperApiURL = options.webRTCHelperApiURL;
     this.#coturnDomainName = options.coturnDomainName;
   }

--- a/packages/local-webrtc-browser-sdk/src/sdk/host-webrtc-connection-manager.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/host-webrtc-connection-manager.ts
@@ -3,10 +3,16 @@ import { issueCoturnCredential } from "../webrtc-helper/issue-coturn-credential"
 /** 接続中 */
 type Connected = {
   type: "connected";
-  /** WebRTCコネクション */
-  connection: RTCPeerConnection;
-  /** データチャンネル */
-  dataChannel: RTCDataChannel;
+  /** 
+   * コネクションPromise
+   * コネクションの重複作成を防ぐために、コネクションとデータチャンネルのセットをPromiseで保持する
+   */
+  connectionPromise: Promise<{
+    /** WebRTCコネクション */
+    connection: RTCPeerConnection;
+    /** データチャンネル */
+    dataChannel: RTCDataChannel;
+  }>;
 };
 
 /** 切断中 */
@@ -55,34 +61,14 @@ export class HostWebRTCConnectionManager {
     dataChannel: RTCDataChannel;
   }> {
     if (this.#connectionState.type === "disconnected") {
-      const { username, password: credential } = await issueCoturnCredential(
-        this.#webRTCHelperApiURL,
-      );
-      const connection = new RTCPeerConnection({
-        iceServers: [
-          {
-            urls: [`stun:${this.#coturnDomainName}:3478`],
-          },
-          {
-            urls: [
-              `turn:${this.#coturnDomainName}:3478?transport=udp`,
-              `turn:${this.#coturnDomainName}:3478?transport=tcp`,
-              `turns:${this.#coturnDomainName}:5349?transport=tcp`,
-            ],
-            username,
-            credential,
-          },
-        ],
-      });
-      const dataChannel = connection.createDataChannel("sendDataChannel");
+      const connectionPromise = this.#createConnectionPromise();
       this.#connectionState = {
         type: "connected",
-        connection,
-        dataChannel,
+        connectionPromise,
       };
     }
 
-    return this.#connectionState;
+    return await this.#connectionState.connectionPromise;
   }
 
   /**
@@ -90,9 +76,41 @@ export class HostWebRTCConnectionManager {
    */
   disconnect() {
     if (this.#connectionState.type === "connected") {
-      this.#connectionState.connection.close();
-      this.#connectionState.dataChannel.close();
+      this.#connectionState.connectionPromise.then(
+        ({ connection, dataChannel }) => {
+          connection.close();
+          dataChannel.close();
+        },
+      );
     }
     this.#connectionState = { type: "disconnected" };
+  }
+
+  /**
+   * コネクションPromiseを生成する
+   * @returns コネクションPromise
+   */
+  async #createConnectionPromise() {
+    const { username, password: credential } = await issueCoturnCredential(
+      this.#webRTCHelperApiURL,
+    );
+    const connection = new RTCPeerConnection({
+      iceServers: [
+        {
+          urls: [`stun:${this.#coturnDomainName}:3478`],
+        },
+        {
+          urls: [
+            `turn:${this.#coturnDomainName}:3478?transport=udp`,
+            `turn:${this.#coturnDomainName}:3478?transport=tcp`,
+            `turns:${this.#coturnDomainName}:5349?transport=tcp`,
+          ],
+          username,
+          credential,
+        },
+      ],
+    });
+    const dataChannel = connection.createDataChannel("sendDataChannel");
+    return { connection, dataChannel };
   }
 }

--- a/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-guest-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-guest-sdk.ts
@@ -10,7 +10,10 @@ import { joinRoom } from "../ws-signal/join-room";
 import { sendGuestSignal } from "../ws-signal/send-guest-signal";
 import { BattleSDK } from "./battle-sdk";
 import { GuestBattleSDK } from "./guest-battle-sdk";
-import { GuestWebRTCConnectionManager } from "./guest-webrtc-connection-manager";
+import {
+  GuestWebRTCConnectionManager,
+  GuestWebRTCConnectionManagerOptions,
+} from "./guest-webrtc-connection-manager";
 import { WebSocketConnectionManager } from "./websocket-connection-manager";
 
 /** ローカルWebRTCゲスト用SDK */
@@ -49,6 +52,12 @@ export type LocalWebRTCGuestSDK = {
   disconnectWebRTC(): void;
 };
 
+/** LocalWebRTCGuestSDKImplコンストラクタのオプション */
+type LocalWebRTCGuestSDKImplOptions = GuestWebRTCConnectionManagerOptions & {
+  /** WebSocketシグナルサーバーのURL */
+  wsSignalUrl: string;
+};
+
 /** ローカルWebRTCゲスト用SDKの実装 */
 class LocalWebRTCGuestSDKImpl implements LocalWebRTCGuestSDK {
   /** WebRTCコネクションマネージャー */
@@ -59,15 +68,8 @@ class LocalWebRTCGuestSDKImpl implements LocalWebRTCGuestSDK {
   /**
    * コンストラクタ
    * @param options コンストラクタのオプション
-   * @param options.webRTCHelperApiURL WebRTCヘルパーAPIのURL
-   * @param options.coturnDomainName coturnサーバーのドメイン名
-   * @param wsSignalUrl WebSocketシグナルサーバーのURL
    */
-  constructor(options: {
-    wsSignalUrl: string;
-    webRTCHelperApiURL: string;
-    coturnDomainName: string;
-  }) {
+  constructor(options: LocalWebRTCGuestSDKImplOptions) {
     const { wsSignalUrl } = options;
     this.#webRTCConnection = new GuestWebRTCConnectionManager(options);
     this.#websocketConnection = new WebSocketConnectionManager(wsSignalUrl);
@@ -177,15 +179,11 @@ class LocalWebRTCGuestSDKImpl implements LocalWebRTCGuestSDK {
 
 /**
  * ローカルWebRTCゲスト用SDKを生成する
- * @param wsSignalUrl WebSocketシグナルサーバーのURL
- * @param webRTCHelperApiURL WebRTCヘルパーAPIのURL
- * @param coturnDomainName coturnサーバーのドメイン名
+ * @param options オプション
  * @returns ローカルWebRTCゲスト用SDKのインスタンス
  */
-export function createLocalWebRTCGuestSDK(options: {
-  wsSignalUrl: string;
-  webRTCHelperApiURL: string;
-  coturnDomainName: string;
-}): LocalWebRTCGuestSDK {
+export function createLocalWebRTCGuestSDK(
+  options: LocalWebRTCGuestSDKImplOptions,
+): LocalWebRTCGuestSDK {
   return new LocalWebRTCGuestSDKImpl(options);
 }

--- a/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-guest-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-guest-sdk.ts
@@ -58,10 +58,18 @@ class LocalWebRTCGuestSDKImpl implements LocalWebRTCGuestSDK {
 
   /**
    * コンストラクタ
+   * @param options コンストラクタのオプション
+   * @param options.webRTCHelperApiURL WebRTCヘルパーAPIのURL
+   * @param options.coturnDomainName coturnサーバーのドメイン名
    * @param wsSignalUrl WebSocketシグナルサーバーのURL
    */
-  constructor(wsSignalUrl: string) {
-    this.#webRTCConnection = new GuestWebRTCConnectionManager();
+  constructor(options: {
+    wsSignalUrl: string;
+    webRTCHelperApiURL: string;
+    coturnDomainName: string;
+  }) {
+    const { wsSignalUrl } = options;
+    this.#webRTCConnection = new GuestWebRTCConnectionManager(options);
     this.#websocketConnection = new WebSocketConnectionManager(wsSignalUrl);
   }
 
@@ -170,10 +178,14 @@ class LocalWebRTCGuestSDKImpl implements LocalWebRTCGuestSDK {
 /**
  * ローカルWebRTCゲスト用SDKを生成する
  * @param wsSignalUrl WebSocketシグナルサーバーのURL
+ * @param webRTCHelperApiURL WebRTCヘルパーAPIのURL
+ * @param coturnDomainName coturnサーバーのドメイン名
  * @returns ローカルWebRTCゲスト用SDKのインスタンス
  */
-export function createLocalWebRTCGuestSDK(
-  wsSignalUrl: string,
-): LocalWebRTCGuestSDK {
-  return new LocalWebRTCGuestSDKImpl(wsSignalUrl);
+export function createLocalWebRTCGuestSDK(options: {
+  wsSignalUrl: string;
+  webRTCHelperApiURL: string;
+  coturnDomainName: string;
+}): LocalWebRTCGuestSDK {
+  return new LocalWebRTCGuestSDKImpl(options);
 }

--- a/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-guest-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-guest-sdk.ts
@@ -85,12 +85,12 @@ class LocalWebRTCGuestSDKImpl implements LocalWebRTCGuestSDK {
 
     const requestSelectedPlayerPromise = (async () => {
       const dataChannel =
-        await this.#webRTCConnection.getOrCreateConnection().dataChannel;
+        await this.#webRTCConnection.getOrCreateConnection().dataChannelPromise;
       return await receiveRequestSelectedPlayer(dataChannel);
     })();
     const battleStartPromise = (async () => {
       const dataChannel =
-        await this.#webRTCConnection.getOrCreateConnection().dataChannel;
+        await this.#webRTCConnection.getOrCreateConnection().dataChannelPromise;
       return await receiveBattleStart(dataChannel);
     })();
 
@@ -101,7 +101,7 @@ class LocalWebRTCGuestSDKImpl implements LocalWebRTCGuestSDK {
 
     const { flowID } = await requestSelectedPlayerPromise;
     const dataChannel =
-      await this.#webRTCConnection.getOrCreateConnection().dataChannel;
+      await this.#webRTCConnection.getOrCreateConnection().dataChannelPromise;
     sendGuestMessage(dataChannel, {
       type: "send-player",
       flowID,
@@ -148,7 +148,8 @@ class LocalWebRTCGuestSDKImpl implements LocalWebRTCGuestSDK {
 
       const { sdp: hostSDP, iceCandidates: hostIceCandidates } =
         joinRoomAccepted;
-      const { connection } = this.#webRTCConnection.getOrCreateConnection();
+      const connection =
+        await this.#webRTCConnection.getOrCreateConnection().connectionPromise;
       await connection.setRemoteDescription(hostSDP);
       await Promise.all(
         hostIceCandidates.map((c) => connection.addIceCandidate(c)),

--- a/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-guest-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-guest-sdk.ts
@@ -178,13 +178,16 @@ class LocalWebRTCGuestSDKImpl implements LocalWebRTCGuestSDK {
   }
 }
 
+/** LocalWebRTCGuestSDKを生成するオプション */
+type CreateLocalWebRTCGuestSDKOptions = LocalWebRTCGuestSDKImplOptions;
+
 /**
  * ローカルWebRTCゲスト用SDKを生成する
  * @param options オプション
  * @returns ローカルWebRTCゲスト用SDKのインスタンス
  */
 export function createLocalWebRTCGuestSDK(
-  options: LocalWebRTCGuestSDKImplOptions,
+  options: CreateLocalWebRTCGuestSDKOptions,
 ): LocalWebRTCGuestSDK {
   return new LocalWebRTCGuestSDKImpl(options);
 }

--- a/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-host-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-host-sdk.ts
@@ -3,7 +3,10 @@ import { Observable } from "rxjs";
 
 import { waitUntilIceCandidate } from "../webrtc/wait-untilIce-candidate";
 import { createRoom } from "../ws-signal/create-room";
-import { HostWebRTCConnectionManager } from "./host-webrtc-connection-manager";
+import {
+  HostWebRTCConnectionManager,
+  HostWebRTCConnectionManagerOptions,
+} from "./host-webrtc-connection-manager";
 import { LocalWebRTCRoom, LocalWebRTCRoomImpl } from "./local-webrtc-room";
 import { WebSocketConnectionManager } from "./websocket-connection-manager";
 
@@ -41,6 +44,12 @@ export type LocalWebRTCHostSDK = {
   disconnectWebRTC(): void;
 };
 
+/** LocalWebRTCHostSDKImplコンストラクタのオプション */
+type LocalWebRTCHostSDKImplOptions = HostWebRTCConnectionManagerOptions & {
+  /** WebSocketシグナルサーバーのURL */
+  wsSignalUrl: string;
+};
+
 /** ローカルWebRTCホスト用SDKの実装 */
 class LocalWebRTCHostSDKImpl implements LocalWebRTCHostSDK {
   /** WebRTCコネクションマネージャー */
@@ -51,15 +60,8 @@ class LocalWebRTCHostSDKImpl implements LocalWebRTCHostSDK {
   /**
    * コンストラクタ
    * @param options コンストラクタのオプション
-   * @param wsSignalUrl WebSocketシグナルサーバーのURL
-   * @param options.webRTCHelperApiURL WebRTCヘルパーAPIのURL
-   * @param options.coturnDomainName coturnサーバーのドメイン名
    */
-  constructor(options: {
-    wsSignalUrl: string;
-    webRTCHelperApiURL: string;
-    coturnDomainName: string;
-  }) {
+  constructor(options: LocalWebRTCHostSDKImplOptions) {
     const { wsSignalUrl } = options;
     this.#websocketConnection = new WebSocketConnectionManager(wsSignalUrl);
     this.#webRTCConnection = new HostWebRTCConnectionManager(options);
@@ -119,15 +121,10 @@ class LocalWebRTCHostSDKImpl implements LocalWebRTCHostSDK {
 /**
  * ローカルWebRTCホスト用SDKを生成する
  * @param options SDK生成のオプション
- * @param options.wsSignalUrl WebSocketシグナルサーバーのURL
- * @param options.webRTCHelperApiURL WebRTCヘルパーAPIのURL
- * @param options.coturnDomainName coturnサーバーのドメイン名
  * @returns ローカルWebRTCホスト用SDKのインスタンス
  */
-export function createLocalWebRTCHostSDK(options: {
-  wsSignalUrl: string;
-  webRTCHelperApiURL: string;
-  coturnDomainName: string;
-}): LocalWebRTCHostSDK {
+export function createLocalWebRTCHostSDK(
+  options: LocalWebRTCHostSDKImplOptions,
+): LocalWebRTCHostSDK {
   return new LocalWebRTCHostSDKImpl(options);
 }

--- a/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-host-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-host-sdk.ts
@@ -50,11 +50,19 @@ class LocalWebRTCHostSDKImpl implements LocalWebRTCHostSDK {
 
   /**
    * コンストラクタ
+   * @param options コンストラクタのオプション
    * @param wsSignalUrl WebSocketシグナルサーバーのURL
+   * @param options.webRTCHelperApiURL WebRTCヘルパーAPIのURL
+   * @param options.coturnDomainName coturnサーバーのドメイン名
    */
-  constructor(wsSignalUrl: string) {
+  constructor(options: {
+    wsSignalUrl: string;
+    webRTCHelperApiURL: string;
+    coturnDomainName: string;
+  }) {
+    const { wsSignalUrl } = options;
     this.#websocketConnection = new WebSocketConnectionManager(wsSignalUrl);
-    this.#webRTCConnection = new HostWebRTCConnectionManager();
+    this.#webRTCConnection = new HostWebRTCConnectionManager(options);
   }
 
   /** @override */
@@ -110,11 +118,16 @@ class LocalWebRTCHostSDKImpl implements LocalWebRTCHostSDK {
 
 /**
  * ローカルWebRTCホスト用SDKを生成する
- * @param wsSignalUrl WebSocketシグナルサーバーのURL
+ * @param options SDK生成のオプション
+ * @param options.wsSignalUrl WebSocketシグナルサーバーのURL
+ * @param options.webRTCHelperApiURL WebRTCヘルパーAPIのURL
+ * @param options.coturnDomainName coturnサーバーのドメイン名
  * @returns ローカルWebRTCホスト用SDKのインスタンス
  */
-export function createLocalWebRTCHostSDK(
-  wsSignalUrl: string,
-): LocalWebRTCHostSDK {
-  return new LocalWebRTCHostSDKImpl(wsSignalUrl);
+export function createLocalWebRTCHostSDK(options: {
+  wsSignalUrl: string;
+  webRTCHelperApiURL: string;
+  coturnDomainName: string;
+}): LocalWebRTCHostSDK {
+  return new LocalWebRTCHostSDKImpl(options);
 }

--- a/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-host-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-host-sdk.ts
@@ -119,13 +119,16 @@ class LocalWebRTCHostSDKImpl implements LocalWebRTCHostSDK {
   }
 }
 
+/** LocalWebRTCHostSDKを生成するオプション */
+type CreateLocalWebRTCHostSDKOptions = LocalWebRTCHostSDKImplOptions;
+
 /**
  * ローカルWebRTCホスト用SDKを生成する
  * @param options SDK生成のオプション
  * @returns ローカルWebRTCホスト用SDKのインスタンス
  */
 export function createLocalWebRTCHostSDK(
-  options: LocalWebRTCHostSDKImplOptions,
+  options: CreateLocalWebRTCHostSDKOptions,
 ): LocalWebRTCHostSDK {
   return new LocalWebRTCHostSDKImpl(options);
 }

--- a/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-host-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-host-sdk.ts
@@ -73,7 +73,8 @@ class LocalWebRTCHostSDKImpl implements LocalWebRTCHostSDK {
     pilotId: PilotId;
   }): Promise<LocalWebRTCRoom | null> {
     try {
-      const { connection } = this.#webRTCConnection.getOrCreateConnection();
+      const { connection } =
+        await this.#webRTCConnection.getOrCreateConnection();
       const sdp = await connection.createOffer();
       const [iceCandidates] = await Promise.all([
         // icecandidateイベントはsetLocalDescriptionの後に発生するため、先に待機しておく

--- a/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-host-sdk.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-host-sdk.ts
@@ -73,8 +73,8 @@ class LocalWebRTCHostSDKImpl implements LocalWebRTCHostSDK {
     pilotId: PilotId;
   }): Promise<LocalWebRTCRoom | null> {
     try {
-      const { connection } =
-        await this.#webRTCConnection.getOrCreateConnection();
+      const connection =
+        await this.#webRTCConnection.getOrCreateConnection().connectionPromise;
       const sdp = await connection.createOffer();
       const [iceCandidates] = await Promise.all([
         // icecandidateイベントはsetLocalDescriptionの後に発生するため、先に待機しておく

--- a/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-room.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-room.ts
@@ -69,7 +69,8 @@ export class LocalWebRTCRoomImpl implements LocalWebRTCRoom {
    * @returns マッチングしたら発火するPromise
    */
   async waitUntilMatching(): Promise<BattleSDK> {
-    const { dataChannel } = this.#webRTCConnection.getOrCreateConnection();
+    const { dataChannel } =
+      await this.#webRTCConnection.getOrCreateConnection();
     await Promise.all([
       this.#signaling(),
       waitUntilDataChannelOpen(dataChannel),
@@ -102,7 +103,8 @@ export class LocalWebRTCRoomImpl implements LocalWebRTCRoom {
     try {
       const websocket = await this.#websocketConnection.getOrCreate();
       const signal = await waitUntilMatching(websocket);
-      const { connection } = this.#webRTCConnection.getOrCreateConnection();
+      const { connection } =
+        await this.#webRTCConnection.getOrCreateConnection();
       await connection.setRemoteDescription(signal.sdp);
       await Promise.all([
         ...signal.iceCandidates.map((c) => connection.addIceCandidate(c)),

--- a/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-room.ts
+++ b/packages/local-webrtc-browser-sdk/src/sdk/local-webrtc-room.ts
@@ -69,8 +69,8 @@ export class LocalWebRTCRoomImpl implements LocalWebRTCRoom {
    * @returns マッチングしたら発火するPromise
    */
   async waitUntilMatching(): Promise<BattleSDK> {
-    const { dataChannel } =
-      await this.#webRTCConnection.getOrCreateConnection();
+    const dataChannel =
+      await this.#webRTCConnection.getOrCreateConnection().dataChannelPromise;
     await Promise.all([
       this.#signaling(),
       waitUntilDataChannelOpen(dataChannel),
@@ -103,8 +103,8 @@ export class LocalWebRTCRoomImpl implements LocalWebRTCRoom {
     try {
       const websocket = await this.#websocketConnection.getOrCreate();
       const signal = await waitUntilMatching(websocket);
-      const { connection } =
-        await this.#webRTCConnection.getOrCreateConnection();
+      const connection =
+        await this.#webRTCConnection.getOrCreateConnection().connectionPromise;
       await connection.setRemoteDescription(signal.sdp);
       await Promise.all([
         ...signal.iceCandidates.map((c) => connection.addIceCandidate(c)),

--- a/packages/local-webrtc-browser-sdk/src/webrtc-helper/issue-coturn-credential.ts
+++ b/packages/local-webrtc-browser-sdk/src/webrtc-helper/issue-coturn-credential.ts
@@ -1,0 +1,20 @@
+import { parseJSON } from "../json/parse";
+import {
+  IssueCoturnCredentialResponse,
+  IssueCoturnCredentialResponseSchema,
+} from "./response/issue-coturn-credential";
+
+/**
+ * coturnクレデンシャルを発行する
+ * @param apiURL WebRTCヘルパーREST APIのURL
+ * @returns 発行したクレデンシャル
+ */
+export const issueCoturnCredential = async (
+  apiURL: string,
+): Promise<IssueCoturnCredentialResponse> => {
+  const response = await fetch(`${apiURL}/coturn/credentials`, {
+    method: "POST",
+  });
+  const body = parseJSON(response.body);
+  return IssueCoturnCredentialResponseSchema.parse(body);
+};

--- a/packages/local-webrtc-browser-sdk/src/webrtc-helper/issue-coturn-credential.ts
+++ b/packages/local-webrtc-browser-sdk/src/webrtc-helper/issue-coturn-credential.ts
@@ -1,4 +1,3 @@
-import { parseJSON } from "../json/parse";
 import {
   IssueCoturnCredentialResponse,
   IssueCoturnCredentialResponseSchema,
@@ -15,6 +14,6 @@ export const issueCoturnCredential = async (
   const response = await fetch(`${apiURL}/coturn/credentials`, {
     method: "POST",
   });
-  const body = parseJSON(response.body);
+  const body = await response.json();
   return IssueCoturnCredentialResponseSchema.parse(body);
 };

--- a/packages/local-webrtc-browser-sdk/src/webrtc-helper/issue-coturn-credential.ts
+++ b/packages/local-webrtc-browser-sdk/src/webrtc-helper/issue-coturn-credential.ts
@@ -14,6 +14,10 @@ export const issueCoturnCredential = async (
   const response = await fetch(`${apiURL}/coturn/credentials`, {
     method: "POST",
   });
+  if (response.status !== 201) {
+    throw new Error(`Failed to issue coturn credential: ${response.status}`);
+  }
+
   const body = await response.json();
   return IssueCoturnCredentialResponseSchema.parse(body);
 };

--- a/packages/local-webrtc-browser-sdk/src/webrtc-helper/response/issue-coturn-credential.ts
+++ b/packages/local-webrtc-browser-sdk/src/webrtc-helper/response/issue-coturn-credential.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+/** coturn用クレデンシャル発行結果 */
+export type IssueCoturnCredentialResponse = {
+  /** ユーザー名 */
+  username: string;
+  /** パスワード */
+  password: string;
+};
+
+/** IssueCoturnCredentialResponse zod スキーマ */
+export const IssueCoturnCredentialResponseSchema = z.object({
+  username: z.string(),
+  password: z.string(),
+});

--- a/packages/local-webrtc-stub/.env.template
+++ b/packages/local-webrtc-stub/.env.template
@@ -1,2 +1,8 @@
 # WebSocketシグナルサーバーのURL
 WS_SIGNAL_SERVER_URL=
+
+# WebRTC Helper APIのURL
+WEBRTC_HELPER_API_URL=
+
+# coturnサーバーのドメイン名
+COTURN_DOMAIN_NAME=

--- a/packages/local-webrtc-stub/src/index.ts
+++ b/packages/local-webrtc-stub/src/index.ts
@@ -9,6 +9,10 @@ import { UseCase } from "./use-case/use-case";
 
 /** WebSocketシグナルサーバーのURL */
 const WS_SIGNAL_SERVER_URL = process.env.WS_SIGNAL_SERVER_URL || "";
+/** WebRTC Helper APIのURL */
+const WEBRTC_HELPER_API_URL = process.env.WEBRTC_HELPER_API_URL || "";
+/** coturnサーバーのドメイン名 */
+const COTURN_DOMAIN_NAME = process.env.COTURN_DOMAIN_NAME || "";
 
 /**
  * ユースケースセレクターを取得する
@@ -49,8 +53,16 @@ const getRoomIDInput = (): HTMLInputElement => {
  * エントリポイント
  */
 window.onload = () => {
-  const hostSDK = createLocalWebRTCHostSDK(WS_SIGNAL_SERVER_URL);
-  const guestSDK = createLocalWebRTCGuestSDK(WS_SIGNAL_SERVER_URL);
+  const hostSDK = createLocalWebRTCHostSDK({
+    wsSignalUrl: WS_SIGNAL_SERVER_URL,
+    webRTCHelperApiURL: WEBRTC_HELPER_API_URL,
+    coturnDomainName: COTURN_DOMAIN_NAME,
+  });
+  const guestSDK = createLocalWebRTCGuestSDK({
+    wsSignalUrl: WS_SIGNAL_SERVER_URL,
+    webRTCHelperApiURL: WEBRTC_HELPER_API_URL,
+    coturnDomainName: COTURN_DOMAIN_NAME,
+  });
   const useCases: UseCase[] = [
     new HostPlayer(hostSDK),
     new GuestPlayer(guestSDK),

--- a/packages/local-webrtc-stub/webpack.config.js
+++ b/packages/local-webrtc-stub/webpack.config.js
@@ -44,6 +44,12 @@ module.exports = {
       "process.env.WS_SIGNAL_SERVER_URL": JSON.stringify(
         process.env.WS_SIGNAL_SERVER_URL,
       ),
+      "process.env.WEBRTC_HELPER_API_URL": JSON.stringify(
+        process.env.WEBRTC_HELPER_API_URL,
+      ),
+      "process.env.COTURN_DOMAIN_NAME": JSON.stringify(
+        process.env.COTURN_DOMAIN_NAME,
+      ),
     }),
   ],
 };


### PR DESCRIPTION
This pull request refactors the WebRTC connection management in the local WebRTC browser SDK to support asynchronous connection establishment and dynamic coturn credential acquisition. The changes introduce new options for specifying the WebRTC helper API URL and coturn domain, and shift the SDK's connection and data channel handling to use Promises for improved reliability and flexibility. This affects both the host and guest SDKs, as well as their connection managers and related classes.

Key changes include:

### WebRTC Connection Management Refactor

- Refactored both `HostWebRTCConnectionManager` and `GuestWebRTCConnectionManager` to:
  - Accept options for `webRTCHelperApiURL` and `coturnDomainName` via their constructors.
  - Use Promises (`connectionPromise` and `dataChannelPromise`) for asynchronous connection and data channel creation, replacing direct references to `RTCPeerConnection` and `RTCDataChannel`. [[1]](diffhunk://#diff-524943de82dcdb45bf7c5f378ede672c5fac9100a46585540e92483074889c8cR2-R10) [[2]](diffhunk://#diff-524943de82dcdb45bf7c5f378ede672c5fac9100a46585540e92483074889c8cR21-R44) [[3]](diffhunk://#diff-524943de82dcdb45bf7c5f378ede672c5fac9100a46585540e92483074889c8cL32-R68) [[4]](diffhunk://#diff-524943de82dcdb45bf7c5f378ede672c5fac9100a46585540e92483074889c8cL54-R85) [[5]](diffhunk://#diff-d51c0578c15e6cafa8cb300d99f2b99bdac376168c655c530a1f5af72df58312R1-R9) [[6]](diffhunk://#diff-d51c0578c15e6cafa8cb300d99f2b99bdac376168c655c530a1f5af72df58312R20-R68) [[7]](diffhunk://#diff-d51c0578c15e6cafa8cb300d99f2b99bdac376168c655c530a1f5af72df58312L52-R85)

- Added a new utility function `createRTCPeerConnection` that:
  - Dynamically fetches coturn credentials from the WebRTC helper API.
  - Configures the ICE servers for the peer connection using the provided coturn domain and credentials.

### SDK and API Changes

- Updated the host and guest SDKs (`LocalWebRTCHostSDK`, `LocalWebRTCGuestSDK`) to:
  - Accept a new options object including the WebRTC helper API URL and coturn domain.
  - Pass these options to their respective connection managers. [[1]](diffhunk://#diff-2b3b017d70a1178af5ffca37b0c9a850a6be43e2b52521321f310195b8974822L6-R9) [[2]](diffhunk://#diff-2b3b017d70a1178af5ffca37b0c9a850a6be43e2b52521321f310195b8974822R47-R52) [[3]](diffhunk://#diff-2b3b017d70a1178af5ffca37b0c9a850a6be43e2b52521321f310195b8974822L53-R67) [[4]](diffhunk://#diff-2b3b017d70a1178af5ffca37b0c9a850a6be43e2b52521321f310195b8974822L66-R77) [[5]](diffhunk://#diff-2b3b017d70a1178af5ffca37b0c9a850a6be43e2b52521321f310195b8974822L113-R130) [[6]](diffhunk://#diff-bb3e1dbc5d7f5792dfb2e81a80d0b81cb1ce885efe93d298d58d32941b5a8131L13-R16) [[7]](diffhunk://#diff-bb3e1dbc5d7f5792dfb2e81a80d0b81cb1ce885efe93d298d58d32941b5a8131R55-R60) [[8]](diffhunk://#diff-bb3e1dbc5d7f5792dfb2e81a80d0b81cb1ce885efe93d298d58d32941b5a8131L61-R74) [[9]](diffhunk://#diff-bb3e1dbc5d7f5792dfb2e81a80d0b81cb1ce885efe93d298d58d32941b5a8131L172-R189)

- Updated all usages of connection and data channel access throughout the SDK (including `LocalWebRTCRoomImpl`, `HostBattleSDK`, `GuestBattleSDK`, and related functions) to use the new Promise-based API (`connectionPromise` and `dataChannelPromise`). [[1]](diffhunk://#diff-801ea79999c05afc41856b3732c5590224f2629092689b5be63ff608878d92b1L75-R78) [[2]](diffhunk://#diff-801ea79999c05afc41856b3732c5590224f2629092689b5be63ff608878d92b1L92-R100) [[3]](diffhunk://#diff-e02bde35a5f486b076ee9635197bcd4b8c6d0d0b5df659ab7f8c4d1e7ea7d6baL72-R73) [[4]](diffhunk://#diff-e02bde35a5f486b076ee9635197bcd4b8c6d0d0b5df659ab7f8c4d1e7ea7d6baL105-R107) [[5]](diffhunk://#diff-bb3e1dbc5d7f5792dfb2e81a80d0b81cb1ce885efe93d298d58d32941b5a8131L78-R93) [[6]](diffhunk://#diff-bb3e1dbc5d7f5792dfb2e81a80d0b81cb1ce885efe93d298d58d32941b5a8131L94-R104) [[7]](diffhunk://#diff-bb3e1dbc5d7f5792dfb2e81a80d0b81cb1ce885efe93d298d58d32941b5a8131L141-R152) [[8]](diffhunk://#diff-85be2065732c38f053f6ecac72a0703b2068ba464e39cac672d2b006b1e8b66bL48-R48)

### Backwards-Incompatible API Updates

- Changed the public SDK creation functions (`createLocalWebRTCHostSDK`, `createLocalWebRTCGuestSDK`) to accept the new options object instead of just the WebSocket signal URL. [[1]](diffhunk://#diff-2b3b017d70a1178af5ffca37b0c9a850a6be43e2b52521321f310195b8974822L113-R130) [[2]](diffhunk://#diff-bb3e1dbc5d7f5792dfb2e81a80d0b81cb1ce885efe93d298d58d32941b5a8131L172-R189)

These changes improve the flexibility and reliability of WebRTC connection handling, enable dynamic coturn credential management, and pave the way for better error handling and future scalability.