### PR TITLE
WebRTC Helper APIでSecret Manager取得用IAMロールを修正

### DIFF
--- a/packages/ws-signal/serverless.yml
+++ b/packages/ws-signal/serverless.yml
@@ -68,7 +68,7 @@ provider:
           Action:
             - "secretsmanager:GetSecretValue"
           Resource:
-            - "arn:aws:secretsmanager:${self:provider.region}:${aws:accountId}:secret:/GbraverBurst/${sls:stage}/*"
+            - "arn:aws:secretsmanager:${self:provider.region}:${aws:accountId}:secret:/GbraverBurst/*"
 
 functions:
   connect:

--- a/packages/ws-signal/serverless.yml
+++ b/packages/ws-signal/serverless.yml
@@ -68,7 +68,7 @@ provider:
           Action:
             - "secretsmanager:GetSecretValue"
           Resource:
-            - "arn:aws:secretsmanager:${self:provider.region}:${aws:accountId}:secret:/GbraverBurst/*"
+            - "arn:aws:secretsmanager:${self:provider.region}:${aws:accountId}:secret:${env:COTURN_SHARED_SECRET}*"
 
 functions:
   connect:


### PR DESCRIPTION
This pull request includes a minor update to the AWS Secrets Manager resource policy in the `serverless.yml` configuration. The change broadens the resource ARN pattern, allowing access to all secrets under `/GbraverBurst/` regardless of stage.

- Configuration update:
  * [`packages/ws-signal/serverless.yml`](diffhunk://#diff-0d8a1225fbe14f1b772b1a4c3a2612a1b1ffe6b6bdda1c0082f828b804aa0eebL71-R71): Updated the `Resource` ARN for `secretsmanager:GetSecretValue` to match all secrets under `/GbraverBurst/`, removing the stage-specific filter.