### PR TITLE
プライベートマッチの入室にルーム存在チェックを追加した

### DIFF
--- a/packages/backend-app/src/enter-private-match-room.ts
+++ b/packages/backend-app/src/enter-private-match-room.ts
@@ -4,6 +4,7 @@ import { Notifier } from "./api-gateway/notifier";
 import { PrivateMatchEntry } from "./core/private-match-entry";
 import { createDynamoConnections } from "./dynamo-db/create-dynamo-connections";
 import { createDynamoPrivateMatchEntries } from "./dynamo-db/create-dynamo-private-match-entries";
+import { createDynamoPrivateMatchRooms } from "./dynamo-db/create-dynamo-private-match-rooms";
 import { createDynamoDBDocument } from "./dynamo-db/dynamo-db-document";
 import { parseJSON } from "./json/parse";
 import { extractUserFromWebSocketAuthorizer } from "./lambda/extract-user";
@@ -26,6 +27,12 @@ const WEBSOCKET_API_ID = process.env.WEBSOCKET_API_ID ?? "";
 const dynamoDB = createDynamoDBDocument(AWS_REGION);
 /** DynamoDBコネクションステート */
 const dynamoConnections = createDynamoConnections(dynamoDB, SERVICE, STAGE);
+/** DynamoDBプライベートマッチルーム */
+const dynamoPrivateMatchRooms = createDynamoPrivateMatchRooms(
+  dynamoDB,
+  SERVICE,
+  STAGE,
+);
 /** DynamoDBプライベートマッチエントリー */
 const dynamoPrivateMatchEntries = createDynamoPrivateMatchEntries(
   dynamoDB,
@@ -49,6 +56,7 @@ const invalidRequestBody: WebsocketAPIResponse = {
   statusCode: 400,
   body: "invalid request body",
 };
+
 /** 無効なリクエストボディのエラー */
 const invalidRequestBodyError: Error = {
   action: "error",
@@ -77,6 +85,12 @@ export async function enterPrivateMatchRoom(
 
   const { roomID } = data;
   if (roomID === "") {
+    await notifier.notifyToClient(connectionId, rejectPrivateMatchEntry);
+    return invalidRequestBody;
+  }
+
+  const room = await dynamoPrivateMatchRooms.get(roomID);
+  if (!room) {
     await notifier.notifyToClient(connectionId, rejectPrivateMatchEntry);
     return invalidRequestBody;
   }

--- a/packages/backend-app/src/enter-private-match-room.ts
+++ b/packages/backend-app/src/enter-private-match-room.ts
@@ -75,7 +75,8 @@ export async function enterPrivateMatchRoom(
     return invalidRequestBody;
   }
 
-  if (data.roomID === "") {
+  const { roomID } = data;
+  if (roomID === "") {
     await notifier.notifyToClient(connectionId, rejectPrivateMatchEntry);
     return invalidRequestBody;
   }
@@ -83,22 +84,21 @@ export async function enterPrivateMatchRoom(
   const user = extractUserFromWebSocketAuthorizer(
     event.requestContext.authorizer,
   );
+  const { userID } = user;
+  const { armdozerId, pilotId } = data;
   const entry: PrivateMatchEntry = {
-    roomID: data.roomID,
-    userID: user.userID,
-    armdozerId: data.armdozerId,
-    pilotId: data.pilotId,
+    roomID,
+    userID,
+    armdozerId,
+    pilotId,
     connectionId,
   };
   await Promise.all([
     dynamoPrivateMatchEntries.put(entry),
     dynamoConnections.put({
       connectionId,
-      userID: user.userID,
-      state: {
-        type: "PrivateMatchMaking",
-        roomID: data.roomID,
-      },
+      userID,
+      state: { type: "PrivateMatchMaking", roomID },
     }),
   ]);
 

--- a/packages/backend-app/src/enter-private-match-room.ts
+++ b/packages/backend-app/src/enter-private-match-room.ts
@@ -67,21 +67,16 @@ const rejectPrivateMatchEntry: RejectPrivateMatchEntry = {
 export async function enterPrivateMatchRoom(
   event: WebsocketAPIEvent,
 ): Promise<WebsocketAPIResponse> {
+  const { connectionId } = event.requestContext;
   const body = parseJSON(event.body);
   const data = parseEnterPrivateMatchRoom(body);
   if (!data) {
-    await notifier.notifyToClient(
-      event.requestContext.connectionId,
-      invalidRequestBodyError,
-    );
+    await notifier.notifyToClient(connectionId, invalidRequestBodyError);
     return invalidRequestBody;
   }
 
   if (data.roomID === "") {
-    await notifier.notifyToClient(
-      event.requestContext.connectionId,
-      rejectPrivateMatchEntry,
-    );
+    await notifier.notifyToClient(connectionId, rejectPrivateMatchEntry);
     return invalidRequestBody;
   }
 
@@ -93,12 +88,12 @@ export async function enterPrivateMatchRoom(
     userID: user.userID,
     armdozerId: data.armdozerId,
     pilotId: data.pilotId,
-    connectionId: event.requestContext.connectionId,
+    connectionId,
   };
   await Promise.all([
     dynamoPrivateMatchEntries.put(entry),
     dynamoConnections.put({
-      connectionId: event.requestContext.connectionId,
+      connectionId,
       userID: user.userID,
       state: {
         type: "PrivateMatchMaking",

--- a/packages/backend-app/src/enter-private-match-room.ts
+++ b/packages/backend-app/src/enter-private-match-room.ts
@@ -10,39 +10,51 @@ import { extractUserFromWebSocketAuthorizer } from "./lambda/extract-user";
 import { WebsocketAPIEvent } from "./lambda/websocket-api-event";
 import { WebsocketAPIResponse } from "./lambda/websocket-api-response";
 import { parseEnterPrivateMatchRoom } from "./request/enter-private-match-room";
-import type { Error } from "./response/error";
-import type { RejectPrivateMatchEntry } from "./response/reject-private-match-entry";
+import { Error } from "./response/error";
+import { RejectPrivateMatchEntry } from "./response/reject-private-match-entry";
 
+/** AWSリージョン */
 const AWS_REGION = process.env.AWS_REGION ?? "";
+/** サービス名 */
 const SERVICE = process.env.SERVICE ?? "";
+/** ステージ */
 const STAGE = process.env.STAGE ?? "";
+/** WebSocket API ID */
 const WEBSOCKET_API_ID = process.env.WEBSOCKET_API_ID ?? "";
 
+/** DynamoDBドキュメントクライアント */
 const dynamoDB = createDynamoDBDocument(AWS_REGION);
+/** DynamoDBコネクションステート */
 const dynamoConnections = createDynamoConnections(dynamoDB, SERVICE, STAGE);
+/** DynamoDBプライベートマッチエントリー */
 const dynamoPrivateMatchEntries = createDynamoPrivateMatchEntries(
   dynamoDB,
   SERVICE,
   STAGE,
 );
 
+/** API Gatewayエンドポイント */
 const apiGatewayEndpoint = createAPIGatewayEndpoint(
   WEBSOCKET_API_ID,
   AWS_REGION,
   STAGE,
 );
+/** API Gateway Management API */
 const apiGateway = createApiGatewayManagementApi(apiGatewayEndpoint);
+/** 通知オブジェクト */
 const notifier = new Notifier(apiGateway);
 
+/** 無効なリクエストボディ */
 const invalidRequestBody: WebsocketAPIResponse = {
   statusCode: 400,
   body: "invalid request body",
 };
-
+/** 無効なリクエストボディのエラー */
 const invalidRequestBodyError: Error = {
   action: "error",
   error: "invalid request body",
 };
+/** プライベートマッチエントリー拒否のレスポンス */
 const rejectPrivateMatchEntry: RejectPrivateMatchEntry = {
   action: "reject-private-match-entry",
 };


### PR DESCRIPTION
This pull request refactors and enhances the `enter-private-match-room` logic to improve code clarity, maintainability, and robustness when handling private match room entries. The most important changes include the introduction of room existence validation, improved variable handling, and clearer initialization of dependencies and constants.

### Private Match Room Validation
* Added a check to ensure the specified room exists by querying `dynamoPrivateMatchRooms.get(roomID)`, and rejects the entry if the room does not exist.

### Variable and Parameter Refactoring
* Extracted frequently used properties (`connectionId`, `roomID`, `userID`, `armdozerId`, `pilotId`) into local variables for cleaner and more readable code.
* Replaced direct property access with these variables throughout the function.

### Dependency and Constant Initialization
* Moved the initialization of dependencies (e.g., `dynamoPrivateMatchRooms`, `notifier`) and constants (e.g., `AWS_REGION`, `SERVICE`, `STAGE`, etc.) to the top of the file with clear comments, improving organization and readability.

### Error Handling Improvements
* Standardized error and rejection responses by defining `invalidRequestBodyError` and `rejectPrivateMatchEntry` constants, and ensured they are used consistently in error cases. [[1]](diffhunk://#diff-36d20105aa4088fca75830f0e826155ace241aad85f093d7ea2e2f2597010a8dR7-R65) [[2]](diffhunk://#diff-36d20105aa4088fca75830f0e826155ace241aad85f093d7ea2e2f2597010a8dR78-R115)

### Type Import Consistency
* Changed `Error` and `RejectPrivateMatchEntry` imports from type-only to regular imports to ensure proper usage at runtime.