### PR TITLE
COTURN_SHARED_SECRETのシークレット定義をコメントアウトし、変数セクションを整理

### DIFF
--- a/buildspec.prod.yml
+++ b/buildspec.prod.yml
@@ -1,7 +1,7 @@
 version: 0.2
 env:
-  variables:
-    # COTURN_SHARED_SECRET: /GbraverBurst/prod/coturnSharedSecret # あいことば対戦を本番リリースするまでコメントアウト
+  # variables:
+  #   COTURN_SHARED_SECRET: /GbraverBurst/prod/coturnSharedSecret #あいことば対戦を本番リリースするまでコメントアウト
   parameter-store:
     SERVICE: /GbraverBurst/prod/service
     WS_SIGNAL_SERVICE: /GbraverBurst/prod/wsSignalService


### PR DESCRIPTION
build spec.ymlでvariablesになにも定義されておらずにエラーが出ていたので、項目全体をコメントアウトした。