### PR TITLE
WS_SIGNAL_SERVICEおよび関連するWebRTCヘルパーのシークレット定義をコメントアウトし、変数セクションを整理

### DIFF
--- a/buildspec.prod.yml
+++ b/buildspec.prod.yml
@@ -4,15 +4,15 @@ env:
   #   COTURN_SHARED_SECRET: /GbraverBurst/prod/coturnSharedSecret #あいことば対戦を本番リリースするまでコメントアウト
   parameter-store:
     SERVICE: /GbraverBurst/prod/service
-    WS_SIGNAL_SERVICE: /GbraverBurst/prod/wsSignalService
+    # WS_SIGNAL_SERVICE: /GbraverBurst/prod/wsSignalService
     STAGE: /GbraverBurst/prod/stage
     WS_API_DOMAIN_NAME: /GbraverBurst/prod/wsApiDomainName
     WS_API_CERT_ARN: /GbraverBurst/prod/wsApiCertArn
-    WS_SIGNAL_DOMAIN_NAME: /GbraverBurst/prod/wsSignalDomainName
-    WS_SIGNAL_CERT_ARN: /GbraverBurst/prod/wsSignalCertArn
-    WEBRTC_HELPER_DOMAIN_NAME: /GbraverBurst/prod/webrtcHelperDomainName
-    WEBRTC_HELPER_CERT_ARN: /GbraverBurst/prod/webrtcHelperCertArn
-    WEBRTC_HELPER_CORS_ORIGIN: /GbraverBurst/prod/webrtcHelperCorsOrigin
+    # WS_SIGNAL_DOMAIN_NAME: /GbraverBurst/prod/wsSignalDomainName #あいことば対戦を本番リリースするまでコメントアウト
+    # WS_SIGNAL_CERT_ARN: /GbraverBurst/prod/wsSignalCertArn #あいことば対戦を本番リリースするまでコメントアウト
+    # WEBRTC_HELPER_DOMAIN_NAME: /GbraverBurst/prod/webrtcHelperDomainName #あいことば対戦を本番リリースするまでコメントアウト
+    # WEBRTC_HELPER_CERT_ARN: /GbraverBurst/prod/webrtcHelperCertArn #あいことば対戦を本番リリースするまでコメントアウト
+    # WEBRTC_HELPER_CORS_ORIGIN: /GbraverBurst/prod/webrtcHelperCorsOrigin #あいことば対戦を本番リリースするまでコメントアウト
     COGNITO_USER_POOL_ID: /GbraverBurst/prod/cognitoUserPoolId
     COGNITO_CLIENT_ID: /GbraverBurst/prod/cognitoClientId
     DOCKER_USER: /GbraverBurst/prod/dockerUser
@@ -33,4 +33,4 @@ phases:
       - ./deploy-serverless.bash
       - ./push-match-make-container.bash
       - ./deploy-backend-ecs.bash
-      # - ./deploy-ws-signal.bash # あいことば対戦を本番リリースするまでコメントアウト
+      # - ./deploy-ws-signal.bash #あいことば対戦を本番リリースするまでコメントアウト


### PR DESCRIPTION
This pull request makes a small change to the production build specification by commenting out several environment variables related to the signal service and WebRTC helper. These variables are now disabled until the "あいことば対戦" (passcode battle) feature is released to production.