### PR TITLE
リリースブランチのdevelopへのマージ

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -339,6 +339,7 @@ AWS Parameter Storeに以下の値をセットする。
 | /GbraverBurst/prod/vpcSubnetCount             | String       | [環境変数定義の定義](#環境変数の定義) VPC_SUBNET_COUNT を参照               |
 | /GbraverBurst/prod/serverlessAccessKey        | SecureString | serverless dashboardから発行したaccesskey                                   |
 
+<!-- あいことば対戦を本番リリースするまでコメントアウト
 #### AWS Secrets Manager
 
 AWS Secrets Managerに以下のシークレットをセットする。
@@ -346,6 +347,7 @@ AWS Secrets Managerに以下のシークレットをセットする。
 | シークレットの名前                    | シークレットのタイプ                                              |
 | ------------------------------------- | ----------------------------------------------------------------- |
 | /GbraverBurst/prod/coturnSharedSecret | [環境変数定義の定義](#環境変数の定義) COTURN_SHARED_SECRET を参照 |
+-->
 
 #### Code Build
 

--- a/Readme.md
+++ b/Readme.md
@@ -322,15 +322,9 @@ AWS Parameter Storeに以下の値をセットする。
 | 名前                                          | 種類         | 値                                                                          |
 | --------------------------------------------- | ------------ | --------------------------------------------------------------------------- |
 | /GbraverBurst/prod/service                    | String       | [環境変数定義の定義](#環境変数の定義) SERVICE を参照                        |
-| /GbraverBurst/prod/wsSignalService            | String       | [環境変数定義の定義](#環境変数の定義) WS_SIGNAL_SERVICE を参照              |
 | /GbraverBurst/prod/stage                      | String       | [環境変数定義の定義](#環境変数の定義) STAGE を参照                          |
 | /GbraverBurst/prod/wsApiDomainName            | String       | [環境変数定義の定義](#環境変数の定義) WS_API_DOMAIN_NAME を参照             |
 | /GbraverBurst/prod/wsApiCertArn               | String       | [環境変数定義の定義](#環境変数の定義) WS_API_CERT_ARN を参照                |
-| /GbraverBurst/prod/wsSignalDomainName         | String       | [環境変数定義の定義](#環境変数の定義) WS_SIGNAL_DOMAIN_NAME を参照          |
-| /GbraverBurst/prod/wsSignalCertArn            | String       | [環境変数定義の定義](#環境変数の定義) WS_SIGNAL_CERT_ARN を参照             |
-| /GbraverBurst/prod/webrtcHelperDomainName     | String       | [環境変数定義の定義](#環境変数の定義) WEBRTC_HELPER_DOMAIN_NAME を参照      |
-| /GbraverBurst/prod/webrtcHelperCertArn        | String       | [環境変数定義の定義](#環境変数の定義) WEBRTC_HELPER_CERT_ARN を参照         |
-| /GbraverBurst/prod/webrtcHelperCorsOrigin     | String       | [環境変数定義の定義](#環境変数の定義) WEBRTC_HELPER_CORS_ORIGIN を参照      |
 | /GbraverBurst/prod/cognitoUserPoolId          | String       | [環境変数定義の定義](#環境変数の定義) COGNITO_USER_POOL_ID を参照           |
 | /GbraverBurst/prod/cognitoClientId            | String       | [環境変数定義の定義](#環境変数の定義) COGNITO_CLIENT_ID を参照              |
 | /GbraverBurst/prod/matchMakeEcrRepositoryName | String       | [環境変数定義の定義](#環境変数の定義) MATCH_MAKE_ECR_REPOSITORY_NAME を参照 |
@@ -339,26 +333,15 @@ AWS Parameter Storeに以下の値をセットする。
 | /GbraverBurst/prod/vpcSubnetCount             | String       | [環境変数定義の定義](#環境変数の定義) VPC_SUBNET_COUNT を参照               |
 | /GbraverBurst/prod/serverlessAccessKey        | SecureString | serverless dashboardから発行したaccesskey                                   |
 
-<!-- あいことば対戦を本番リリースするまでコメントアウト
-#### AWS Secrets Manager
-
-AWS Secrets Managerに以下のシークレットをセットする。
-
-| シークレットの名前                    | シークレットのタイプ                                              |
-| ------------------------------------- | ----------------------------------------------------------------- |
-| /GbraverBurst/prod/coturnSharedSecret | [環境変数定義の定義](#環境変数の定義) COTURN_SHARED_SECRET を参照 |
--->
-
 #### Code Build
 
 以下のCode Buildプロジェクトを生成する。
 
-| 役割                 | buildspec                            | 環境                                                                                                                       | 　webhook                                   |
-| -------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| デプロイ             | buildspec.prod.yml                   | [amazonlinux-aarch64-standard:3.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/al/aarch64/standard/3.0) | [本番環境CD用webhook](#本番環境cd用webhook) |
-| serverless削除       | buildspec.sls.remove.prod.yml        | [amazonlinux-aarch64-standard:3.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/al/aarch64/standard/3.0) | なし                                        |
-| バックエンドECS削除  | buildspec.backendEcs.remove.prod.yml | [amazonlinux-aarch64-standard:3.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/al/aarch64/standard/3.0) | なし                                        |
-| シグナルサーバー削除 | buildspec.wsSignal.remove.prod.yml   | [amazonlinux-aarch64-standard:3.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/al/aarch64/standard/3.0) | なし                                        |
+| 役割                | buildspec                            | 環境                                                                                                                       | 　webhook                                   |
+| ------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| デプロイ            | buildspec.prod.yml                   | [amazonlinux-aarch64-standard:3.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/al/aarch64/standard/3.0) | [本番環境CD用webhook](#本番環境cd用webhook) |
+| serverless削除      | buildspec.sls.remove.prod.yml        | [amazonlinux-aarch64-standard:3.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/al/aarch64/standard/3.0) | なし                                        |
+| バックエンドECS削除 | buildspec.backendEcs.remove.prod.yml | [amazonlinux-aarch64-standard:3.0](https://github.com/aws/aws-codebuild-docker-images/tree/master/al/aarch64/standard/3.0) | なし                                        |
 
 ##### webhook
 

--- a/buildspec.prod.yml
+++ b/buildspec.prod.yml
@@ -1,7 +1,7 @@
 version: 0.2
 env:
   variables:
-    COTURN_SHARED_SECRET: /GbraverBurst/prod/coturnSharedSecret
+    # COTURN_SHARED_SECRET: /GbraverBurst/prod/coturnSharedSecret # あいことば対戦を本番リリースするまでコメントアウト
   parameter-store:
     SERVICE: /GbraverBurst/prod/service
     WS_SIGNAL_SERVICE: /GbraverBurst/prod/wsSignalService

--- a/buildspec.prod.yml
+++ b/buildspec.prod.yml
@@ -1,7 +1,7 @@
 version: 0.2
 env:
-  variables:
-    # COTURN_SHARED_SECRET: /GbraverBurst/prod/coturnSharedSecret # あいことば対戦を本番リリースするまでコメントアウト
+  # variables:
+  #   COTURN_SHARED_SECRET: /GbraverBurst/prod/coturnSharedSecret #あいことば対戦を本番リリースするまでコメントアウト
   parameter-store:
     SERVICE: /GbraverBurst/prod/service
     WS_SIGNAL_SERVICE: /GbraverBurst/prod/wsSignalService

--- a/buildspec.prod.yml
+++ b/buildspec.prod.yml
@@ -4,15 +4,15 @@ env:
   #   COTURN_SHARED_SECRET: /GbraverBurst/prod/coturnSharedSecret #あいことば対戦を本番リリースするまでコメントアウト
   parameter-store:
     SERVICE: /GbraverBurst/prod/service
-    WS_SIGNAL_SERVICE: /GbraverBurst/prod/wsSignalService
+    # WS_SIGNAL_SERVICE: /GbraverBurst/prod/wsSignalService
     STAGE: /GbraverBurst/prod/stage
     WS_API_DOMAIN_NAME: /GbraverBurst/prod/wsApiDomainName
     WS_API_CERT_ARN: /GbraverBurst/prod/wsApiCertArn
-    WS_SIGNAL_DOMAIN_NAME: /GbraverBurst/prod/wsSignalDomainName
-    WS_SIGNAL_CERT_ARN: /GbraverBurst/prod/wsSignalCertArn
-    WEBRTC_HELPER_DOMAIN_NAME: /GbraverBurst/prod/webrtcHelperDomainName
-    WEBRTC_HELPER_CERT_ARN: /GbraverBurst/prod/webrtcHelperCertArn
-    WEBRTC_HELPER_CORS_ORIGIN: /GbraverBurst/prod/webrtcHelperCorsOrigin
+    # WS_SIGNAL_DOMAIN_NAME: /GbraverBurst/prod/wsSignalDomainName #あいことば対戦を本番リリースするまでコメントアウト
+    # WS_SIGNAL_CERT_ARN: /GbraverBurst/prod/wsSignalCertArn #あいことば対戦を本番リリースするまでコメントアウト
+    # WEBRTC_HELPER_DOMAIN_NAME: /GbraverBurst/prod/webrtcHelperDomainName #あいことば対戦を本番リリースするまでコメントアウト
+    # WEBRTC_HELPER_CERT_ARN: /GbraverBurst/prod/webrtcHelperCertArn #あいことば対戦を本番リリースするまでコメントアウト
+    # WEBRTC_HELPER_CORS_ORIGIN: /GbraverBurst/prod/webrtcHelperCorsOrigin #あいことば対戦を本番リリースするまでコメントアウト
     COGNITO_USER_POOL_ID: /GbraverBurst/prod/cognitoUserPoolId
     COGNITO_CLIENT_ID: /GbraverBurst/prod/cognitoClientId
     DOCKER_USER: /GbraverBurst/prod/dockerUser
@@ -33,4 +33,4 @@ phases:
       - ./deploy-serverless.bash
       - ./push-match-make-container.bash
       - ./deploy-backend-ecs.bash
-      # - ./deploy-ws-signal.bash # あいことば対戦を本番リリースするまでコメントアウト
+      # - ./deploy-ws-signal.bash #あいことば対戦を本番リリースするまでコメントアウト


### PR DESCRIPTION
This pull request updates environment variable and secret management for the production deployment, mainly by commenting out or removing parameters and secrets related to the "あいことば対戦" (password match) feature, which is not yet ready for production release. It also updates documentation to reflect these changes.

**Environment variable and secret management changes:**

* Commented out all parameters and secrets related to the "あいことば対戦" feature (such as `COTURN_SHARED_SECRET`, `WS_SIGNAL_SERVICE`, `WS_SIGNAL_DOMAIN_NAME`, `WS_SIGNAL_CERT_ARN`, `WEBRTC_HELPER_DOMAIN_NAME`, `WEBRTC_HELPER_CERT_ARN`, and `WEBRTC_HELPER_CORS_ORIGIN`) in both the `buildspec.prod.yml` and the documentation, indicating these will be enabled when the feature is ready for production. [[1]](diffhunk://#diff-95a4779a60c8981757068733208a2aeb744c9097412aa27da62fbd0b6442e8caL3-R15) [[2]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L325-L333)

**Documentation updates:**

* Removed the section about setting the `COTURN_SHARED_SECRET` in AWS Secrets Manager and updated the table of AWS Parameter Store variables to match the commented-out configuration.
* Removed the documentation entry for the signal server deletion CodeBuild project, reflecting that it is no longer relevant with the current production configuration.