### PR TITLE
Node.jsのバージョンを24.14.1から24.15.0にアップデート

### DIFF
--- a/packages/backend-app/matchMake.Dockerfile
+++ b/packages/backend-app/matchMake.Dockerfile
@@ -1,5 +1,5 @@
 # docker buildの前にbuild:match-makeを実行すること
-FROM node:24.14.1-trixie-slim
+FROM node:24.15.0-trixie-slim
 WORKDIR /usr/src/app
 COPY ./ /usr/src/app
 # SIGTERMを適切に処理できるように、


### PR DESCRIPTION
This pull request makes a minor update to the Dockerfile for the match-making backend app by upgrading the Node.js base image to version 24.15.0. This ensures the app uses the latest bug fixes and security patches.