### PR TITLE
WebSocketオーサライザーのJWT検証失敗時にDenyを指定するようにした

### DIFF
--- a/packages/backend-app/src/authorizer.ts
+++ b/packages/backend-app/src/authorizer.ts
@@ -1,4 +1,5 @@
 import { CognitoAccessTokenPayload } from "aws-jwt-verify/jwt-model";
+
 import { verifyAccessTokenFromCognito } from "./cognito/verify-access-token";
 import { AuthorizerEvent } from "./lambda/authorizer-event";
 import {
@@ -22,7 +23,7 @@ export async function authorizer(
   event: AuthorizerEvent,
 ): Promise<AuthorizerResponse> {
   const resource = event.methodArn;
-  let token: CognitoAccessTokenPayload | null = null;
+  let token: CognitoAccessTokenPayload;
   try {
     token = await verifyAccessTokenFromCognito(
       COGNITO_USER_POOL_ID,

--- a/packages/backend-app/src/authorizer.ts
+++ b/packages/backend-app/src/authorizer.ts
@@ -1,7 +1,9 @@
+import { CognitoAccessTokenPayload } from "aws-jwt-verify/jwt-model";
 import { verifyAccessTokenFromCognito } from "./cognito/verify-access-token";
 import { AuthorizerEvent } from "./lambda/authorizer-event";
 import {
   AuthorizerResponse,
+  failedAuthorize,
   successAuthorize,
 } from "./lambda/authorizer-response";
 
@@ -19,12 +21,19 @@ const COGNITO_CLIENT_ID = process.env.COGNITO_CLIENT_ID ?? "";
 export async function authorizer(
   event: AuthorizerEvent,
 ): Promise<AuthorizerResponse> {
-  const token = await verifyAccessTokenFromCognito(
-    COGNITO_USER_POOL_ID,
-    COGNITO_CLIENT_ID,
-    event.queryStringParameters.token,
-  );
-  const principalId = token.sub ?? "";
-  const resource: string = event.methodArn;
+  const resource = event.methodArn;
+  let token: CognitoAccessTokenPayload | null = null;
+  try {
+    token = await verifyAccessTokenFromCognito(
+      COGNITO_USER_POOL_ID,
+      COGNITO_CLIENT_ID,
+      event.queryStringParameters.token,
+    );
+  } catch (error) {
+    console.error("Failed to verify access token", error);
+    return failedAuthorize("", resource);
+  }
+
+  const principalId = token.sub;
   return successAuthorize(principalId, resource);
 }


### PR DESCRIPTION
This pull request improves the error handling in the `authorizer` function by adding proper handling for failed Cognito access token verification. Now, if token verification fails, the function logs the error and returns a failed authorization response instead of throwing an uncaught exception.

**Authorization logic improvements:**

* Enhanced the `authorizer` function in `authorizer.ts` to catch errors during Cognito access token verification, log the error, and return a failed authorization response using `failedAuthorize`. This prevents unhandled exceptions and ensures a consistent response when token verification fails.

**Dependency and import updates:**

* Added import for `CognitoAccessTokenPayload` and `failedAuthorize` to support the improved error handling and type safety in `authorizer.ts`.