### PR TITLE
v1.24.0をリリース

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19211,7 +19211,7 @@
     },
     "packages/aws-vpc": {
       "name": "@gbraver-burst-network/aws-vpc",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "aws-cdk-lib": "^2.253.1",
@@ -19250,7 +19250,7 @@
     },
     "packages/backend-app": {
       "name": "@gbraver-burst-network/backend-app",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.1045.0",
@@ -19301,7 +19301,7 @@
     },
     "packages/backend-ecs": {
       "name": "@gbraver-burst-network/backend-ecs",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "@types/ramda": "^0.31.1",
@@ -19342,7 +19342,7 @@
     },
     "packages/browser-sdk": {
       "name": "@gbraver-burst-network/browser-sdk",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "aws-amplify": "^6.17.0",
@@ -19383,7 +19383,7 @@
     },
     "packages/local-webrtc-browser-sdk": {
       "name": "@gbraver-burst-network/local-webrtc-browser-sdk",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.11",
@@ -19418,10 +19418,10 @@
     },
     "packages/local-webrtc-stub": {
       "name": "@gbraver-burst-network/local-webrtc-stub",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
-        "@gbraver-burst-network/local-webrtc-browser-sdk": "1.23.1",
+        "@gbraver-burst-network/local-webrtc-browser-sdk": "1.24.0",
         "dotenv": "^17.4.2",
         "gbraver-burst-core": "^1.44.0"
       },
@@ -19454,7 +19454,7 @@
     },
     "packages/offline-backend-app": {
       "name": "@gbraver-burst-network/offline-backend-app",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.6",
@@ -19494,7 +19494,7 @@
     },
     "packages/offline-browser-sdk": {
       "name": "@gbraver-burst-network/offline-browser-sdk",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "rxjs": "^7.8.2",
@@ -19530,10 +19530,10 @@
     },
     "packages/offline-stub": {
       "name": "@gbraver-burst-network/offline-stub",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
-        "@gbraver-burst-network/offline-browser-sdk": "1.23.1",
+        "@gbraver-burst-network/offline-browser-sdk": "1.24.0",
         "dotenv": "^17.4.2",
         "gbraver-burst-core": "^1.44.0"
       },
@@ -19564,10 +19564,10 @@
     },
     "packages/serverless-stub": {
       "name": "@gbraver-burst-network/serverless-stub",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
-        "@gbraver-burst-network/browser-sdk": "1.23.1",
+        "@gbraver-burst-network/browser-sdk": "1.24.0",
         "dotenv": "^17.4.2",
         "gbraver-burst-core": "^1.44.0"
       },
@@ -19616,7 +19616,7 @@
     },
     "packages/ws-signal": {
       "name": "@gbraver-burst-network/ws-signal",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "@aws-lambda-powertools/parameters": "^2.33.0",

--- a/packages/aws-vpc/CHANGELOG.md
+++ b/packages/aws-vpc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/aws-vpc
 
+## 1.24.0
+
+### Minor Changes
+
+- あいことば対戦に匿名トークンを追加した
+
 ## 1.23.1
 
 ### Patch Changes

--- a/packages/aws-vpc/package.json
+++ b/packages/aws-vpc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/aws-vpc",
   "description": "gbraver burst backend vpc.",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "bin": {
     "aws-vpc": "bin/aws-vpc.js"
   },

--- a/packages/backend-app/CHANGELOG.md
+++ b/packages/backend-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/backend-app
 
+## 1.24.0
+
+### Minor Changes
+
+- あいことば対戦に匿名トークンを追加した
+
 ## 1.23.1
 
 ### Patch Changes

--- a/packages/backend-app/package.json
+++ b/packages/backend-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/backend-app",
   "description": "gbraver burst backend app",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "author": "Y.Takeuchi",
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.1045.0",

--- a/packages/backend-ecs/CHANGELOG.md
+++ b/packages/backend-ecs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/backend-ecs
 
+## 1.24.0
+
+### Minor Changes
+
+- あいことば対戦に匿名トークンを追加した
+
 ## 1.23.1
 
 ### Patch Changes

--- a/packages/backend-ecs/package.json
+++ b/packages/backend-ecs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/backend-ecs",
   "description": "create backend ecs.",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "bin": {
     "backend-ecs": "bin/backend-ecs.js"
   },

--- a/packages/browser-sdk/CHANGELOG.md
+++ b/packages/browser-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/browser-sdk
 
+## 1.24.0
+
+### Minor Changes
+
+- あいことば対戦に匿名トークンを追加した
+
 ## 1.23.1
 
 ### Patch Changes

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/browser-sdk",
   "description": "gbraver burst browser sdk",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "author": "Y.Takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-network/issues",

--- a/packages/local-webrtc-browser-sdk/CHANGELOG.md
+++ b/packages/local-webrtc-browser-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/local-webrtc-browser-sdk
 
+## 1.24.0
+
+### Minor Changes
+
+- あいことば対戦に匿名トークンを追加した
+
 ## 1.23.1
 
 ### Patch Changes

--- a/packages/local-webrtc-browser-sdk/package.json
+++ b/packages/local-webrtc-browser-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/local-webrtc-browser-sdk",
   "description": "gbraver burst local webrtc browser sdk",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "author": "Y.Takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-network/issues",

--- a/packages/local-webrtc-stub/CHANGELOG.md
+++ b/packages/local-webrtc-stub/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @gbraver-burst-network/local-webrtc-stub
 
+## 1.24.0
+
+### Minor Changes
+
+- あいことば対戦に匿名トークンを追加した
+
+### Patch Changes
+
+- Updated dependencies
+  - @gbraver-burst-network/local-webrtc-browser-sdk@1.24.0
+
 ## 1.23.1
 
 ### Patch Changes

--- a/packages/local-webrtc-stub/package.json
+++ b/packages/local-webrtc-stub/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@gbraver-burst-network/local-webrtc-stub",
   "description": "gbraver burst local webrtc stub.",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "author": "Y.Takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-network/issues",
     "email": "kaidouji85@gmail.com"
   },
   "dependencies": {
-    "@gbraver-burst-network/local-webrtc-browser-sdk": "1.23.1",
+    "@gbraver-burst-network/local-webrtc-browser-sdk": "1.24.0",
     "dotenv": "^17.4.2",
     "gbraver-burst-core": "^1.44.0"
   },

--- a/packages/offline-backend-app/CHANGELOG.md
+++ b/packages/offline-backend-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/offline-backend-app
 
+## 1.24.0
+
+### Minor Changes
+
+- あいことば対戦に匿名トークンを追加した
+
 ## 1.23.1
 
 ### Patch Changes

--- a/packages/offline-backend-app/package.json
+++ b/packages/offline-backend-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/offline-backend-app",
   "description": "gbraver burst offline backend app",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "author": "Y.Takeuchi",
   "dependencies": {
     "cors": "^2.8.6",

--- a/packages/offline-browser-sdk/CHANGELOG.md
+++ b/packages/offline-browser-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/offline-browser-sdk
 
+## 1.24.0
+
+### Minor Changes
+
+- あいことば対戦に匿名トークンを追加した
+
 ## 1.23.1
 
 ### Patch Changes

--- a/packages/offline-browser-sdk/package.json
+++ b/packages/offline-browser-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/offline-browser-sdk",
   "description": "gbraver burst offline browser sdk",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "author": "Y.Takeuchi",
   "bugs": {
     "url": "https://github.com/kaidouji85/gbraver-burst-network/issues",

--- a/packages/offline-stub/CHANGELOG.md
+++ b/packages/offline-stub/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @gbraver-burst-network/offline-stub
 
+## 1.24.0
+
+### Minor Changes
+
+- あいことば対戦に匿名トークンを追加した
+
+### Patch Changes
+
+- Updated dependencies
+  - @gbraver-burst-network/offline-browser-sdk@1.24.0
+
 ## 1.23.1
 
 ### Patch Changes

--- a/packages/offline-stub/package.json
+++ b/packages/offline-stub/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@gbraver-burst-network/offline-stub",
   "description": "gbraver burst offline browser sdk",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "author": "Y.Takeuchi",
   "dependencies": {
-    "@gbraver-burst-network/offline-browser-sdk": "1.23.1",
+    "@gbraver-burst-network/offline-browser-sdk": "1.24.0",
     "dotenv": "^17.4.2",
     "gbraver-burst-core": "^1.44.0"
   },

--- a/packages/serverless-stub/CHANGELOG.md
+++ b/packages/serverless-stub/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @gbraver-burst-network/serverless-stub
 
+## 1.24.0
+
+### Minor Changes
+
+- あいことば対戦に匿名トークンを追加した
+
+### Patch Changes
+
+- Updated dependencies
+  - @gbraver-burst-network/browser-sdk@1.24.0
+
 ## 1.23.1
 
 ### Patch Changes

--- a/packages/serverless-stub/package.json
+++ b/packages/serverless-stub/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@gbraver-burst-network/serverless-stub",
   "description": "gbraver burst network stub.",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "author": "Y.Takeuchi",
   "dependencies": {
-    "@gbraver-burst-network/browser-sdk": "1.23.1",
+    "@gbraver-burst-network/browser-sdk": "1.24.0",
     "dotenv": "^17.4.2",
     "gbraver-burst-core": "^1.44.0"
   },

--- a/packages/ws-signal/CHANGELOG.md
+++ b/packages/ws-signal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gbraver-burst-network/ws-signal
 
+## 1.24.0
+
+### Minor Changes
+
+- あいことば対戦に匿名トークンを追加した
+
 ## 1.23.1
 
 ### Patch Changes

--- a/packages/ws-signal/package.json
+++ b/packages/ws-signal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gbraver-burst-network/ws-signal",
   "description": "gbraver burst webrtc signal cache",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "author": "Y.Takeuchi",
   "dependencies": {
     "@aws-lambda-powertools/parameters": "^2.33.0",


### PR DESCRIPTION
This pull request updates multiple packages in the monorepo to version 1.24.0, with the main change being the addition of an anonymous token feature for "あいことば対戦" (keyword battle). The updates are reflected across both core and stub packages, and all relevant dependencies are bumped to maintain consistency.

Feature addition:

* Added anonymous token support to "あいことば対戦" (keyword battle) across all core and SDK packages. [[1]](diffhunk://#diff-a4ee225b383c2e39cb1447ea38ce20f8462216a3de29f8b0ce415c8db3a4685dR3-R8) [[2]](diffhunk://#diff-a70fd3fea3782a67f2de830f3f3000e07ef1eb828347ecd1cb589b79c547779fR3-R8) [[3]](diffhunk://#diff-d08b7108571d480cefcf3071e83fc09f4d767089a32b0cfb4a3476ab91e076ecR3-R8) [[4]](diffhunk://#diff-fd71b57137241809d8a8c569cb843ce8a29d5ee2705306974c4bb249e8eae4d7R3-R8) [[5]](diffhunk://#diff-743836b102ed61599bbe8f6b467d450fb51ca3ee160546c58a3230f4fccaf84cR3-R8) [[6]](diffhunk://#diff-687ab108f6a319d5fc658fecea661d9eed29e5726f18a0a224e1d93de48ebf86R3-R8) [[7]](diffhunk://#diff-19e1855e5e873f97f75d0fe89ab1490ffc2a6287bb2e5f6ed84e6f625f27a88dR3-R8)

Version and dependency updates:

* Bumped version to 1.24.0 in all affected `package.json` and `CHANGELOG.md` files for the following packages: `aws-vpc`, `backend-app`, `backend-ecs`, `browser-sdk`, `local-webrtc-browser-sdk`, `local-webrtc-stub`, `offline-backend-app`, `offline-browser-sdk`, `offline-stub`, and `serverless-stub`. [[1]](diffhunk://#diff-1e1d61e86cebb7496b3ea3d5b51cbbc6a17797a048b7bb331f6105237468e218L4-R4) [[2]](diffhunk://#diff-e8863e6291315635ed6033580947eab3fd63b3762e026775bedd8df074cb941cL4-R4) [[3]](diffhunk://#diff-d09faa1ceef5d3684323489669d6f26951645a3ea38c71c77d44fa7538db8ba9L4-R4) [[4]](diffhunk://#diff-475fbf96532457ba4b9457941110adacea0f854ef45e19448218936a2086e9dbL4-R4) [[5]](diffhunk://#diff-3fc3b905a935ef486d842edd7f2078973010515d87989a98d627afd0d77ec713L4-R4) [[6]](diffhunk://#diff-ad4ef05bfd34d9e39524cd50ce41de28a2dfd17f51846891c392810f1a34e79eL4-R11) [[7]](diffhunk://#diff-12ce8a9bf893a21fbf1126ec9626d07e3d7b9f798e5b7bcb28fd85158bc3384fL4-R4) [[8]](diffhunk://#diff-b8829937252f063f9ae974cfb69d5b61f7910ff558c5f6adf945d6d05a7c79d6L4-R4) [[9]](diffhunk://#diff-dafa27d82b8c53e4e3472b49a356cfdc58a6bd5a434718206693f204e522880cL4-R7) [[10]](diffhunk://#diff-5f72d91b4238ef7c141e9fe955fcc260b841ecf4c2d33f9f55ee8d36b4ac3f42L4-R7)
* Updated internal dependencies in stub packages to reference the new 1.24.0 versions of their respective SDKs. [[1]](diffhunk://#diff-ad4ef05bfd34d9e39524cd50ce41de28a2dfd17f51846891c392810f1a34e79eL4-R11) [[2]](diffhunk://#diff-dafa27d82b8c53e4e3472b49a356cfdc58a6bd5a434718206693f204e522880cL4-R7) [[3]](diffhunk://#diff-5f72d91b4238ef7c141e9fe955fcc260b841ecf4c2d33f9f55ee8d36b4ac3f42L4-R7)

Changelog maintenance:

* Added changelog entries for the new feature and dependency updates in all affected packages. [[1]](diffhunk://#diff-a4ee225b383c2e39cb1447ea38ce20f8462216a3de29f8b0ce415c8db3a4685dR3-R8) [[2]](diffhunk://#diff-a70fd3fea3782a67f2de830f3f3000e07ef1eb828347ecd1cb589b79c547779fR3-R8) [[3]](diffhunk://#diff-d08b7108571d480cefcf3071e83fc09f4d767089a32b0cfb4a3476ab91e076ecR3-R8) [[4]](diffhunk://#diff-fd71b57137241809d8a8c569cb843ce8a29d5ee2705306974c4bb249e8eae4d7R3-R8) [[5]](diffhunk://#diff-743836b102ed61599bbe8f6b467d450fb51ca3ee160546c58a3230f4fccaf84cR3-R8) [[6]](diffhunk://#diff-be0bb91c4fb27efd36f8f9344afa514eb660d4d8dfeb339293a2f2efba2fa988R3-R13) [[7]](diffhunk://#diff-19e1855e5e873f97f75d0fe89ab1490ffc2a6287bb2e5f6ed84e6f625f27a88dR3-R8) [[8]](diffhunk://#diff-687ab108f6a319d5fc658fecea661d9eed29e5726f18a0a224e1d93de48ebf86R3-R8) [[9]](diffhunk://#diff-3ce41f8f41c0dc599478b204c925dc39c43b3ff3d1f99f85295dd83a57a7640dR3-R13) [[10]](diffhunk://#diff-f012c4416a49f6ab20d64a45dbc6b89868b6d5581dafa1dc0b394e0b21399b08R3-R13)