### PR TITLE
gbrver-burst-coreをアップデートした

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10565,9 +10565,9 @@
       }
     },
     "node_modules/gbraver-burst-core": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/gbraver-burst-core/-/gbraver-burst-core-1.44.0.tgz",
-      "integrity": "sha512-yk6oIFhpCJO8S1A0zCV7AY7CiJXvga2J3xkFZo4IF3Ktt1cOe9ZUGRZAaIHbPNM9WbNheAJ5HtNgsspg/n2fAQ==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/gbraver-burst-core/-/gbraver-burst-core-1.45.0.tgz",
+      "integrity": "sha512-NKGUkIjon7O/mxdCoaoeR5O5AN5O3vD3wcXisz3ARU6l4xBeaCXCMwJsf9wTNS8ujtZUQREOT3CcQT2nH8Y9ig==",
       "license": "MIT",
       "dependencies": {
         "ramda": "^0.32.0"
@@ -10576,7 +10576,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "zod": "^4.3.6"
+        "zod": "^4.4.3"
       }
     },
     "node_modules/generator-function": {
@@ -19050,7 +19050,7 @@
         "@aws-sdk/signature-v4-crt": "^3.1068.0",
         "aws-jwt-verify": "^5.2.1",
         "dotenv": "^17.4.2",
-        "gbraver-burst-core": "^1.44.0",
+        "gbraver-burst-core": "^1.45.0",
         "nanoid": "^5.1.11",
         "ramda": "^0.32.0",
         "uuid": "^14.0.0",
@@ -19157,7 +19157,7 @@
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "gbraver-burst-core": "^1.44.0",
+        "gbraver-burst-core": "^1.45.0",
         "zod": "^4.4.3"
       }
     },
@@ -19184,7 +19184,7 @@
         "dependency-cruiser": "^17.4.3",
         "eslint": "^10.5.0",
         "eslint-plugin-simple-import-sort": "^13.0.0",
-        "gbraver-burst-core": "^1.44.0",
+        "gbraver-burst-core": "^1.45.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.8.4",
         "rimraf": "^6.1.3",
@@ -19192,7 +19192,7 @@
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "gbraver-burst-core": "^1.44.0",
+        "gbraver-burst-core": "^1.45.0",
         "zod": "^4.4.3"
       }
     },
@@ -19213,7 +19213,7 @@
       "dependencies": {
         "@gbraver-burst-network/local-webrtc-browser-sdk": "1.25.2",
         "dotenv": "^17.4.2",
-        "gbraver-burst-core": "^1.44.0"
+        "gbraver-burst-core": "^1.45.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -19250,7 +19250,7 @@
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
-        "gbraver-burst-core": "^1.44.0",
+        "gbraver-burst-core": "^1.45.0",
         "p-queue": "^9.3.0",
         "socket.io": "^4.8.3",
         "uuid": "^14.0.0",
@@ -19295,7 +19295,7 @@
         "dependency-cruiser": "^17.4.3",
         "eslint": "^10.5.0",
         "eslint-plugin-simple-import-sort": "^13.0.0",
-        "gbraver-burst-core": "^1.44.0",
+        "gbraver-burst-core": "^1.45.0",
         "npm-run-all": "^4.1.5",
         "prettier": "3.8.4",
         "rimraf": "^6.1.3",
@@ -19304,7 +19304,7 @@
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "gbraver-burst-core": "^1.44.0",
+        "gbraver-burst-core": "^1.45.0",
         "zod": "^4.4.3"
       }
     },
@@ -19325,7 +19325,7 @@
       "dependencies": {
         "@gbraver-burst-network/offline-browser-sdk": "1.25.2",
         "dotenv": "^17.4.2",
-        "gbraver-burst-core": "^1.44.0"
+        "gbraver-burst-core": "^1.45.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -19359,7 +19359,7 @@
       "dependencies": {
         "@gbraver-burst-network/browser-sdk": "1.25.2",
         "dotenv": "^17.4.2",
-        "gbraver-burst-core": "^1.44.0"
+        "gbraver-burst-core": "^1.45.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/packages/backend-app/package.json
+++ b/packages/backend-app/package.json
@@ -11,7 +11,7 @@
     "@aws-sdk/signature-v4-crt": "^3.1068.0",
     "aws-jwt-verify": "^5.2.1",
     "dotenv": "^17.4.2",
-    "gbraver-burst-core": "^1.44.0",
+    "gbraver-burst-core": "^1.45.0",
     "nanoid": "^5.1.11",
     "ramda": "^0.32.0",
     "uuid": "^14.0.0",

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "main": "lib/src/index.js",
   "peerDependencies": {
-    "gbraver-burst-core": "^1.44.0",
+    "gbraver-burst-core": "^1.45.0",
     "zod": "^4.4.3"
   },
   "repository": "https://github.com/kaidouji85/gbraver-burst-network/tree/develop/packages/browser-sdk",

--- a/packages/local-webrtc-browser-sdk/package.json
+++ b/packages/local-webrtc-browser-sdk/package.json
@@ -16,7 +16,7 @@
     "dependency-cruiser": "^17.4.3",
     "eslint": "^10.5.0",
     "eslint-plugin-simple-import-sort": "^13.0.0",
-    "gbraver-burst-core": "^1.44.0",
+    "gbraver-burst-core": "^1.45.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.8.4",
     "rimraf": "^6.1.3",
@@ -34,7 +34,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "peerDependencies": {
-    "gbraver-burst-core": "^1.44.0",
+    "gbraver-burst-core": "^1.45.0",
     "zod": "^4.4.3"
   },
   "repository": "https://github.com/kaidouji85/gbraver-burst-network/tree/develop/packages/local-webrtc-browser-sdk",

--- a/packages/local-webrtc-stub/package.json
+++ b/packages/local-webrtc-stub/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@gbraver-burst-network/local-webrtc-browser-sdk": "1.25.2",
     "dotenv": "^17.4.2",
-    "gbraver-burst-core": "^1.44.0"
+    "gbraver-burst-core": "^1.45.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/offline-backend-app/package.json
+++ b/packages/offline-backend-app/package.json
@@ -7,7 +7,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
-    "gbraver-burst-core": "^1.44.0",
+    "gbraver-burst-core": "^1.45.0",
     "p-queue": "^9.3.0",
     "socket.io": "^4.8.3",
     "uuid": "^14.0.0",

--- a/packages/offline-browser-sdk/package.json
+++ b/packages/offline-browser-sdk/package.json
@@ -16,7 +16,7 @@
     "dependency-cruiser": "^17.4.3",
     "eslint": "^10.5.0",
     "eslint-plugin-simple-import-sort": "^13.0.0",
-    "gbraver-burst-core": "^1.44.0",
+    "gbraver-burst-core": "^1.45.0",
     "npm-run-all": "^4.1.5",
     "prettier": "3.8.4",
     "rimraf": "^6.1.3",
@@ -37,7 +37,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "peerDependencies": {
-    "gbraver-burst-core": "^1.44.0",
+    "gbraver-burst-core": "^1.45.0",
     "zod": "^4.4.3"
   },
   "repository": "https://github.com/kaidouji85/gbraver-burst-network/tree/develop/packages/offline-browser-sdk",

--- a/packages/offline-stub/package.json
+++ b/packages/offline-stub/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@gbraver-burst-network/offline-browser-sdk": "1.25.2",
     "dotenv": "^17.4.2",
-    "gbraver-burst-core": "^1.44.0"
+    "gbraver-burst-core": "^1.45.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/serverless-stub/package.json
+++ b/packages/serverless-stub/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@gbraver-burst-network/browser-sdk": "1.25.2",
     "dotenv": "^17.4.2",
-    "gbraver-burst-core": "^1.44.0"
+    "gbraver-burst-core": "^1.45.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
This pull request updates the `gbraver-burst-core` dependency version from `^1.44.0` to `^1.45.0` across multiple packages in the repository. This ensures that all relevant packages use the latest features and bug fixes from the core library.

Dependency version updates:

* Updated the `gbraver-burst-core` version to `^1.45.0` in the following packages' `dependencies`:
  - `packages/backend-app/package.json`
  - `packages/local-webrtc-stub/package.json`
  - `packages/offline-backend-app/package.json`
  - `packages/offline-stub/package.json`
  - `packages/serverless-stub/package.json`
  - `packages/local-webrtc-browser-sdk/package.json`
  - `packages/offline-browser-sdk/package.json`

* Updated the `gbraver-burst-core` version to `^1.45.0` in the following packages' `peerDependencies`:
  - `packages/browser-sdk/package.json`
  - `packages/local-webrtc-browser-sdk/package.json`
  - `packages/offline-browser-sdk/package.json`