### PR TITLE
coturnのメンテナンス手順を追加した

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -453,15 +453,6 @@ npx changeset publish
 npx changeset pre exit
 ```
 
-## その他コマンド
-
-```shell
-# package.jsonフォーマット
-# 本コマンドの実行にはfixpackが必要
-# https://www.npmjs.com/package/fixpack
-fixpack
-```
-
 ## License
 
 MIT

--- a/coturn-setup.md
+++ b/coturn-setup.md
@@ -238,7 +238,37 @@ const pc = new RTCPeerConnection({
 });
 ```
 
-## 11. 運用上の注意
+## 11. メンテナンス（ソフトウェアアップグレード）
+
+### 11.1. 共通シークレットの更新
+
+本手順を実施する前に、強力な<共通シークレット>をあらかじめ作成しておいてください。
+
+```bash
+# 設定ファイルのバックアップ
+sudo cp /etc/turnserver.conf "/etc/turnserver.conf.bak.$(date +%Y%m%d%H%M%S)"
+
+# 共通シークレットの更新
+NEW_COTURN_SHARED_SECRET=<強力な共通シークレット>
+sudo sed -i "s/^static-auth-secret=.*/static-auth-secret=${NEW_COTURN_SHARED_SECRET}/" /etc/turnserver.conf
+
+# 正しくシークレットが更新されたかを確認
+grep '^static-auth-secret=' /etc/turnserver.conf
+```
+
+### 11.2. ソフトウェアのアップグレード
+
+apt系パッケージを更新します。
+必要に応じて、サーバーを再起動してください。
+
+```bash
+sudo apt update
+sudo apt list --upgradable
+sudo apt upgrade
+sudo apt autoremove
+```
+
+## 12. 運用上の注意
 
 - 共通シークレットは十分に長いランダム値を使用し、定期的に更新してください。
 - さくらのVPSパケットフィルター制約により、リレーポートは`1-32767`の範囲で設計してください。

--- a/coturn-setup.md
+++ b/coturn-setup.md
@@ -265,13 +265,20 @@ grep '^static-auth-secret=' /etc/turnserver.conf
 ### 11.2. ソフトウェアのアップグレード
 
 apt系パッケージを更新します。
-必要に応じて、サーバーを再起動してください。
 
 ```bash
 sudo apt update
 sudo apt list --upgradable
 sudo apt upgrade
 sudo apt autoremove
+```
+
+### 11.3. 再起動
+
+必要に応じて、サーバーを再起動してください。
+
+```bash
+sudo reboot
 ```
 
 ## 12. 運用上の注意

--- a/coturn-setup.md
+++ b/coturn-setup.md
@@ -157,6 +157,12 @@ EOF
 
 - `use-auth-secret`では、アプリサーバーとcoturnが同じ共通シークレットを持ち、アプリサーバー側で一時クレデンシャルを生成してクライアントへ渡します。
 
+> [!NOTE] 強力な共通シークレットの生成コマンド例
+>
+> ```shell
+> openssl rand -base64 32
+> ```
+
 ## 8. 起動と自動起動設定
 
 ```shell
@@ -250,7 +256,7 @@ sudo cp /etc/turnserver.conf "/etc/turnserver.conf.bak.$(date +%Y%m%d%H%M%S)"
 
 # 共通シークレットの更新
 NEW_COTURN_SHARED_SECRET=<強力な共通シークレット>
-sudo sed -i "s/^static-auth-secret=.*/static-auth-secret=${NEW_COTURN_SHARED_SECRET}/" /etc/turnserver.conf
+sudo sed -i "s|^static-auth-secret=.*|static-auth-secret=${NEW_COTURN_SHARED_SECRET}|" /etc/turnserver.conf
 
 # 正しくシークレットが更新されたかを確認
 grep '^static-auth-secret=' /etc/turnserver.conf


### PR DESCRIPTION
This pull request updates documentation related to coturn server setup and maintenance. The main focus is on improving the clarity of security practices for shared secrets, providing explicit maintenance procedures, and cleaning up unnecessary documentation sections.

Security and maintenance improvements in `coturn-setup.md`:

* Added a note with a recommended command for generating a strong shared secret using `openssl rand -base64 32`.
* Introduced a new section on maintenance, detailing procedures for updating the shared secret (with backup and verification steps), upgrading software packages, and rebooting the server as needed.

Documentation cleanup:

* Removed the section about the `fixpack` command from `Readme.md` to streamline the documentation.