### PR TITLE
シグナルサーバーのHTTP APIにアクセスログを追加した

### DIFF
--- a/packages/ws-signal/serverless.yml
+++ b/packages/ws-signal/serverless.yml
@@ -32,6 +32,8 @@ provider:
         functionName: httpAuthorizerFunc
         enableSimpleResponses: true
         payloadVersion: "2.0"
+  logs:
+    httpApi: true
   websocketsApiName: ${self:service}__${sls:stage}__ws-signal
   websocketsApiRouteSelectionExpression: $request.body.action
   environment:

--- a/packages/ws-signal/serverless.yml
+++ b/packages/ws-signal/serverless.yml
@@ -44,7 +44,7 @@ provider:
         "status":"$context.status",
         "protocol":"$context.protocol",
         "responseLength":"$context.responseLength",
-        "principalId":"$context.authorizer.tokenHash",
+        "principalId":"$context.authorizer.principalId",
         "userAgent":"$context.identity.userAgent"
         }
   websocketsApiName: ${self:service}__${sls:stage}__ws-signal

--- a/packages/ws-signal/serverless.yml
+++ b/packages/ws-signal/serverless.yml
@@ -33,7 +33,20 @@ provider:
         enableSimpleResponses: true
         payloadVersion: "2.0"
   logs:
-    httpApi: true
+    httpApi:
+      format: >-
+        {
+        "requestId":"$context.requestId",
+        "ip":"$context.identity.sourceIp",
+        "requestTime":"$context.requestTime",
+        "httpMethod":"$context.httpMethod",
+        "routeKey":"$context.routeKey",
+        "status":"$context.status",
+        "protocol":"$context.protocol",
+        "responseLength":"$context.responseLength",
+        "principalId":"$context.authorizer.principalId",
+        "userAgent":"$context.identity.userAgent"
+        }
   websocketsApiName: ${self:service}__${sls:stage}__ws-signal
   websocketsApiRouteSelectionExpression: $request.body.action
   environment:

--- a/packages/ws-signal/serverless.yml
+++ b/packages/ws-signal/serverless.yml
@@ -44,7 +44,7 @@ provider:
         "status":"$context.status",
         "protocol":"$context.protocol",
         "responseLength":"$context.responseLength",
-        "principalId":"$context.authorizer.principalId",
+        "principalId":"$context.authorizer.tokenHash",
         "userAgent":"$context.identity.userAgent"
         }
   websocketsApiName: ${self:service}__${sls:stage}__ws-signal

--- a/packages/ws-signal/src/http-api-authorizer.ts
+++ b/packages/ws-signal/src/http-api-authorizer.ts
@@ -4,7 +4,7 @@ import {
   APIGatewaySimpleAuthorizerWithContextResult,
 } from "aws-lambda";
 
-import { extractBearerToken, HashAuthToken } from "./core/auth-token";
+import { extractBearerToken } from "./core/auth-token";
 import { DynamoAuthTokens } from "./dynamo-db/dynamo-auth-tokens";
 import { createDynamoDBDocument } from "./dynamo-db/dynamo-db-document";
 

--- a/packages/ws-signal/src/http-api-authorizer.ts
+++ b/packages/ws-signal/src/http-api-authorizer.ts
@@ -21,6 +21,12 @@ const dynamoAuthTokens = new DynamoAuthTokens(
   DYNAMO_AUTH_TOKENS_TABLE,
 );
 
+/** 認証成功時のコンテキスト */
+type HttpAPIGatewayContext = {
+  /** プリンシパルID */
+  principalId: string;
+};
+
 /**
  * HTTP API用のオーソライザー
  * @param event API Gatewayから渡されるイベント
@@ -29,7 +35,7 @@ const dynamoAuthTokens = new DynamoAuthTokens(
 export const httpAPIAuthorizer = async (
   event: APIGatewayProxyEventV2,
 ): Promise<
-  | APIGatewaySimpleAuthorizerWithContextResult<HashAuthToken>
+  | APIGatewaySimpleAuthorizerWithContextResult<HttpAPIGatewayContext>
   | APIGatewaySimpleAuthorizerResult
 > => {
   const token = extractBearerToken(event.headers.authorization || "");
@@ -42,5 +48,5 @@ export const httpAPIAuthorizer = async (
     return { isAuthorized: false };
   }
 
-  return { isAuthorized: true, context: tokenHash };
+  return { isAuthorized: true, context: { principalId: tokenHash.tokenHash } };
 };


### PR DESCRIPTION
This pull request updates the HTTP API authorizer logic in the `ws-signal` package to provide a more structured authorization context and adds enhanced logging for HTTP API requests in the serverless configuration. The main focus is on improving the way authorization context is passed and increasing observability of API requests.

**Authorization context improvements:**

* Introduced a new `HttpAPIGatewayContext` type to explicitly define the context returned on successful authorization, containing a `principalId` field.
* Updated the `httpAPIAuthorizer` function to return the new `HttpAPIGatewayContext` instead of the raw token hash, and set `principalId` to the token hash value. [[1]](diffhunk://#diff-09c2a4c0bbf36cf404374679a60e4688e4928356603e757db779592082778e76L32-R38) [[2]](diffhunk://#diff-09c2a4c0bbf36cf404374679a60e4688e4928356603e757db779592082778e76L45-R51)

**Observability enhancements:**

* Added a custom HTTP API log format in `serverless.yml` to include fields such as `requestId`, `ip`, `requestTime`, `httpMethod`, `routeKey`, `status`, `protocol`, `responseLength`, `principalId`, and `userAgent` for improved tracing and debugging.