### PR TITLE
httpApiのメトリクスを有効にした

### DIFF
--- a/packages/ws-signal/serverless.yml
+++ b/packages/ws-signal/serverless.yml
@@ -32,6 +32,7 @@ provider:
         functionName: httpAuthorizerFunc
         enableSimpleResponses: true
         payloadVersion: "2.0"
+    metrics: true
   logs:
     httpApi:
       format: >-


### PR DESCRIPTION
This pull request introduces a small configuration change to the `serverless.yml` file for the WebSocket provider. The change enables metrics collection for the provider.

* Configuration update:
  * Enabled metrics collection by adding `metrics: true` under the `provider` section in `serverless.yml`.