### PR TITLE
WebSocket APIのアクセルログにプリンシパルIDを追加

### DIFF
--- a/packages/ws-signal/serverless.yml
+++ b/packages/ws-signal/serverless.yml
@@ -50,6 +50,18 @@ provider:
         }
     websocket:
       accessLogging: true
+      format: >-
+        {
+        "ip": "$context.identity.sourceIp",
+        "caller": "$context.identity.caller",
+        "user": "$context.identity.user",
+        "requestTime": "$context.requestTime",
+        "eventType": "$context.eventType",
+        "routeKey": "$context.routeKey",
+        "connectionId": "$context.connectionId",
+        "requestId": "$context.requestId",
+        "principalId": "$context.authorizer.principalId"
+        }
       executionLogging: true
   websocketsApiName: ${self:service}__${sls:stage}__ws-signal
   websocketsApiRouteSelectionExpression: $request.body.action

--- a/packages/ws-signal/serverless.yml
+++ b/packages/ws-signal/serverless.yml
@@ -48,6 +48,7 @@ provider:
         "principalId":"$context.authorizer.principalId",
         "userAgent":"$context.identity.userAgent"
         }
+    websocket: true
   websocketsApiName: ${self:service}__${sls:stage}__ws-signal
   websocketsApiRouteSelectionExpression: $request.body.action
   environment:

--- a/packages/ws-signal/serverless.yml
+++ b/packages/ws-signal/serverless.yml
@@ -48,7 +48,9 @@ provider:
         "principalId":"$context.authorizer.principalId",
         "userAgent":"$context.identity.userAgent"
         }
-    websocket: true
+    websocket:
+      accessLogging: true
+      executionLogging: true
   websocketsApiName: ${self:service}__${sls:stage}__ws-signal
   websocketsApiRouteSelectionExpression: $request.body.action
   environment:


### PR DESCRIPTION
This pull request adds enhanced logging configuration for the WebSocket API in the `serverless.yml` file. The main change is enabling access and execution logging for WebSocket connections, with a custom log format that includes important request and connection details.

**WebSocket API Logging Enhancements:**

* Enabled `accessLogging` and `executionLogging` for the WebSocket API, and added a detailed custom log format to capture key connection and request information such as IP, user, event type, route key, and connection ID (`packages/ws-signal/serverless.yml`).