### PR TITLE
ログインあり対戦サーバーのWebSocketにもアクセスログを追加した

### DIFF
--- a/packages/backend-app/serverless.yml
+++ b/packages/backend-app/serverless.yml
@@ -63,6 +63,22 @@ provider:
             - "execute-api:ManageConnections"
           Resource:
             - "arn:aws:execute-api:*:*:**/@connections/*"
+  logs:
+    websocket:
+      accessLogging: true
+      executionLogging: true
+      format: >-
+        {
+        "ip": "$context.identity.sourceIp",
+        "caller": "$context.identity.caller",
+        "user": "$context.identity.user",
+        "requestTime": "$context.requestTime",
+        "eventType": "$context.eventType",
+        "routeKey": "$context.routeKey",
+        "connectionId": "$context.connectionId",
+        "requestId": "$context.requestId",
+        "principalId": "$context.authorizer.principalId"
+        }
 
 functions:
   webSocketAPIAuthorizer:

--- a/packages/ws-signal/serverless.yml
+++ b/packages/ws-signal/serverless.yml
@@ -33,36 +33,6 @@ provider:
         enableSimpleResponses: true
         payloadVersion: "2.0"
     metrics: true
-  logs:
-    httpApi:
-      format: >-
-        {
-        "requestId":"$context.requestId",
-        "ip":"$context.identity.sourceIp",
-        "requestTime":"$context.requestTime",
-        "httpMethod":"$context.httpMethod",
-        "routeKey":"$context.routeKey",
-        "status":"$context.status",
-        "protocol":"$context.protocol",
-        "responseLength":"$context.responseLength",
-        "principalId":"$context.authorizer.principalId",
-        "userAgent":"$context.identity.userAgent"
-        }
-    websocket:
-      accessLogging: true
-      format: >-
-        {
-        "ip": "$context.identity.sourceIp",
-        "caller": "$context.identity.caller",
-        "user": "$context.identity.user",
-        "requestTime": "$context.requestTime",
-        "eventType": "$context.eventType",
-        "routeKey": "$context.routeKey",
-        "connectionId": "$context.connectionId",
-        "requestId": "$context.requestId",
-        "principalId": "$context.authorizer.principalId"
-        }
-      executionLogging: true
   websocketsApiName: ${self:service}__${sls:stage}__ws-signal
   websocketsApiRouteSelectionExpression: $request.body.action
   environment:
@@ -105,6 +75,36 @@ provider:
             - "secretsmanager:GetSecretValue"
           Resource:
             - "arn:aws:secretsmanager:${self:provider.region}:${aws:accountId}:secret:${env:COTURN_SHARED_SECRET}*"
+  logs:
+    httpApi:
+      format: >-
+        {
+        "requestId":"$context.requestId",
+        "ip":"$context.identity.sourceIp",
+        "requestTime":"$context.requestTime",
+        "httpMethod":"$context.httpMethod",
+        "routeKey":"$context.routeKey",
+        "status":"$context.status",
+        "protocol":"$context.protocol",
+        "responseLength":"$context.responseLength",
+        "principalId":"$context.authorizer.principalId",
+        "userAgent":"$context.identity.userAgent"
+        }
+    websocket:
+      accessLogging: true
+      format: >-
+        {
+        "ip": "$context.identity.sourceIp",
+        "caller": "$context.identity.caller",
+        "user": "$context.identity.user",
+        "requestTime": "$context.requestTime",
+        "eventType": "$context.eventType",
+        "routeKey": "$context.routeKey",
+        "connectionId": "$context.connectionId",
+        "requestId": "$context.requestId",
+        "principalId": "$context.authorizer.principalId"
+        }
+      executionLogging: true
 
 functions:
   # WebSocket API

--- a/packages/ws-signal/serverless.yml
+++ b/packages/ws-signal/serverless.yml
@@ -92,6 +92,7 @@ provider:
         }
     websocket:
       accessLogging: true
+      executionLogging: true
       format: >-
         {
         "ip": "$context.identity.sourceIp",
@@ -104,7 +105,6 @@ provider:
         "requestId": "$context.requestId",
         "principalId": "$context.authorizer.principalId"
         }
-      executionLogging: true
 
 functions:
   # WebSocket API


### PR DESCRIPTION
This pull request updates the logging configuration for the Serverless deployments in both the `backend-app` and `ws-signal` services. The main focus is on standardizing and restoring the HTTP API and WebSocket logging formats, ensuring that detailed logs are captured for both types of APIs.

**Logging configuration updates:**

*Restoration and Standardization of Logging in `ws-signal`:*
- Re-adds and standardizes the `httpApi` and `websocket` logging configuration under `provider.logs`, including detailed log formats for both, after these were previously removed. This ensures consistent and comprehensive logging for HTTP and WebSocket APIs. [[1]](diffhunk://#diff-0d8a1225fbe14f1b772b1a4c3a2612a1b1ffe6b6bdda1c0082f828b804aa0eebL36-L65) [[2]](diffhunk://#diff-0d8a1225fbe14f1b772b1a4c3a2612a1b1ffe6b6bdda1c0082f828b804aa0eebR78-R107)

*Addition of WebSocket Logging in `backend-app`:*
- Adds a `websocket` logging configuration under `provider.logs` in `backend-app/serverless.yml`, enabling both access and execution logging with a detailed format for WebSocket events.