### PR TITLE
ランダムのルームIDにNGワードを設定した

### DIFF
--- a/packages/backend-app/src/core/generate-private-match-room-id.ts
+++ b/packages/backend-app/src/core/generate-private-match-room-id.ts
@@ -39,11 +39,11 @@ const DEFAULT_NG_WORDS = [
 /**
  * プライベートマッチのルームIDを生成する
  * @param ngWords NGワードの配列。指定しない場合はデフォルトのNGワードが使用される
- * @returns 生成されたルームID
+ * @returns 生成されたルームID、または生成に失敗した場合はnull
  */
 export const generatePrivateMatchRoomID = (
   ngWords: string[] = DEFAULT_NG_WORDS,
-): PrivateMatchRoomID => {
+): PrivateMatchRoomID | null => {
   for (let i = 0; i < MAX_ROOM_CREATION_RETRY; i++) {
     const roomID = Array.from(
       { length: ROOM_ID_LENGTH },
@@ -55,7 +55,5 @@ export const generatePrivateMatchRoomID = (
     }
   }
 
-  throw new Error(
-    "failed to create private match room ID after maximum retries",
-  );
+  return null;
 };

--- a/packages/backend-app/src/core/generate-private-match-room-id.ts
+++ b/packages/backend-app/src/core/generate-private-match-room-id.ts
@@ -22,12 +22,40 @@ const kana = [
 /** ルームIDの文字数 */
 const ROOM_ID_LENGTH = 5;
 
+/** ルームIDの最大生成試行回数 */
+const MAX_ROOM_CREATION_RETRY = 5;
+
+/**
+ * デフォルトのNGワード
+ * NGワードをコードに直接記載するのは憚られたので、Unicodeエスケープシーケンスで記載している
+ */
+const DEFAULT_NG_WORDS = [
+  "\u3057\u306d",
+  "\u3053\u308d\u3059",
+  "\u3061\u3093",
+  "\u307e\u3093",
+];
+
 /**
  * プライベートマッチのルームIDを生成する
+ * @param ngWords NGワードの配列。指定しない場合はデフォルトのNGワードが使用される
  * @returns 生成されたルームID
  */
-export const generatePrivateMatchRoomID = (): PrivateMatchRoomID =>
-  Array.from(
-    { length: ROOM_ID_LENGTH },
-    () => kana[crypto.randomInt(kana.length)],
-  ).join("");
+export const generatePrivateMatchRoomID = (
+  ngWords: string[] = DEFAULT_NG_WORDS,
+): PrivateMatchRoomID => {
+  for (let i = 0; i < MAX_ROOM_CREATION_RETRY; i++) {
+    const roomID = Array.from(
+      { length: ROOM_ID_LENGTH },
+      () => kana[crypto.randomInt(kana.length)],
+    ).join("");
+    const hasNGWord = ngWords.some((ngWord) => roomID.includes(ngWord));
+    if (!hasNGWord) {
+      return roomID;
+    }
+  }
+
+  throw new Error(
+    "failed to create private match room ID after maximum retries",
+  );
+};

--- a/packages/backend-app/src/core/generate-private-match-room-id.ts
+++ b/packages/backend-app/src/core/generate-private-match-room-id.ts
@@ -22,9 +22,6 @@ const kana = [
 /** ルームIDの文字数 */
 const ROOM_ID_LENGTH = 5;
 
-/** ルームIDの最大生成試行回数 */
-const MAX_ROOM_CREATION_RETRY = 5;
-
 /**
  * デフォルトのNGワード
  * NGワードをコードに直接記載するのは憚られたので、Unicodeエスケープシーケンスで記載している
@@ -44,16 +41,14 @@ const DEFAULT_NG_WORDS = [
 export const generatePrivateMatchRoomID = (
   ngWords: string[] = DEFAULT_NG_WORDS,
 ): PrivateMatchRoomID | null => {
-  for (let i = 0; i < MAX_ROOM_CREATION_RETRY; i++) {
-    const roomID = Array.from(
-      { length: ROOM_ID_LENGTH },
-      () => kana[crypto.randomInt(kana.length)],
-    ).join("");
-    const hasNGWord = ngWords.some((ngWord) => roomID.includes(ngWord));
-    if (!hasNGWord) {
-      return roomID;
-    }
+  const roomID = Array.from(
+    { length: ROOM_ID_LENGTH },
+    () => kana[crypto.randomInt(kana.length)],
+  ).join("");
+  const hasNGWord = ngWords.some((ngWord) => roomID.includes(ngWord));
+  if (hasNGWord) {
+    return null;
   }
 
-  return null;
+  return roomID;
 };

--- a/packages/backend-app/src/create-private-match-room.ts
+++ b/packages/backend-app/src/create-private-match-room.ts
@@ -74,8 +74,12 @@ async function createRoomWithRetry(options: {
   const { armdozerId, pilotId } = data;
   const { userID: owner } = user;
   for (let i = 0; i < MAX_ROOM_CREATION_RETRY; i++) {
+    const roomID = generatePrivateMatchRoomID();
+    if (!roomID) {
+      continue;
+    }
     const room: PrivateMatchRoom = {
-      roomID: generatePrivateMatchRoomID(),
+      roomID,
       expiresAt: createPrivateMatchRoomExpiresAt(),
       owner,
       ownerConnectionId,

--- a/packages/backend-app/test/src/core/generate-private-match-room-id.test.ts
+++ b/packages/backend-app/test/src/core/generate-private-match-room-id.test.ts
@@ -1,0 +1,55 @@
+import * as crypto from "crypto";
+
+import { generatePrivateMatchRoomID } from "../../../src/core/generate-private-match-room-id";
+
+jest.mock("crypto", () => ({
+  randomInt: jest.fn(),
+}));
+
+/**
+ * モック用のランダムインデックス生成関数
+ * 以下のように、引数に指定したインデックスを順番に返すようにしている
+ * 例: kanaIndexes(0, 1, 2)
+ *     0 -> あ
+ *     1 -> い
+ *     2 -> う
+ * @param indexes 返すインデックスの配列
+ */
+const kanaIndexes = (...indexes: number[]) =>
+  jest.mocked(crypto.randomInt).mockImplementation(() => {
+    const index = indexes.shift();
+    if (index === undefined) {
+      throw new Error("randomInt is called more times than expected");
+    }
+
+    return index;
+  });
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("NGワードを含まないルームIDを返す", () => {
+  kanaIndexes(5, 6, 7, 8, 9);
+  const roomID = generatePrivateMatchRoomID(["あい", "さし"]);
+  expect(roomID).toBe("かきくけこ");
+});
+
+test("NGワードを含む候補は再生成して返す", () => {
+  kanaIndexes(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+  const roomID = generatePrivateMatchRoomID(["あい"]);
+  expect(roomID).toBe("かきくけこ");
+});
+
+test("再生成上限までNGワードに一致するとエラーになる", () => {
+  kanaIndexes(
+    ...[0, 1, 2, 3, 4],
+    ...[0, 1, 2, 3, 4],
+    ...[0, 1, 2, 3, 4],
+    ...[0, 1, 2, 3, 4],
+    ...[0, 1, 2, 3, 4],
+  );
+  expect(() => generatePrivateMatchRoomID(["あい"])).toThrow(
+    "failed to create private match room ID after maximum retries",
+  );
+});

--- a/packages/backend-app/test/src/core/generate-private-match-room-id.test.ts
+++ b/packages/backend-app/test/src/core/generate-private-match-room-id.test.ts
@@ -41,7 +41,7 @@ test("NGワードを含む候補は再生成して返す", () => {
   expect(roomID).toBe("かきくけこ");
 });
 
-test("再生成上限までNGワードに一致するとエラーになる", () => {
+test("再生成上限までNGワードに一致すると失敗してnullを返す", () => {
   kanaIndexes(
     ...[0, 1, 2, 3, 4],
     ...[0, 1, 2, 3, 4],
@@ -49,7 +49,6 @@ test("再生成上限までNGワードに一致するとエラーになる", () 
     ...[0, 1, 2, 3, 4],
     ...[0, 1, 2, 3, 4],
   );
-  expect(() => generatePrivateMatchRoomID(["あい"])).toThrow(
-    "failed to create private match room ID after maximum retries",
-  );
+  const roomID = generatePrivateMatchRoomID(["あい"]);
+  expect(roomID).toBeNull();
 });

--- a/packages/backend-app/test/src/core/generate-private-match-room-id.test.ts
+++ b/packages/backend-app/test/src/core/generate-private-match-room-id.test.ts
@@ -35,20 +35,8 @@ test("NGワードを含まないルームIDを返す", () => {
   expect(roomID).toBe("かきくけこ");
 });
 
-test("NGワードを含む候補は再生成して返す", () => {
+test("NGワードを含む候補は失敗としてnullを返す", () => {
   kanaIndexes(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
-  const roomID = generatePrivateMatchRoomID(["あい"]);
-  expect(roomID).toBe("かきくけこ");
-});
-
-test("再生成上限までNGワードに一致すると失敗してnullを返す", () => {
-  kanaIndexes(
-    ...[0, 1, 2, 3, 4],
-    ...[0, 1, 2, 3, 4],
-    ...[0, 1, 2, 3, 4],
-    ...[0, 1, 2, 3, 4],
-    ...[0, 1, 2, 3, 4],
-  );
   const roomID = generatePrivateMatchRoomID(["あい"]);
   expect(roomID).toBeNull();
 });

--- a/packages/ws-signal/src/core/create-room-id.ts
+++ b/packages/ws-signal/src/core/create-room-id.ts
@@ -20,12 +20,36 @@ const kana = [
 /** ルームIDの文字数 */
 const ROOM_ID_LENGTH = 5;
 
+/** ルームIDの最大生成試行回数 */
+const MAX_ROOM_CREATION_RETRY = 5;
+
+/**
+ * デフォルトのNGワード
+ * NGワードをコードに直接記載するのは憚られたので、Unicodeエスケープシーケンスで記載している
+ */
+const DEFAULT_NG_WORDS = [
+  "\u3057\u306d",
+  "\u3053\u308d\u3059",
+  "\u3061\u3093",
+  "\u307e\u3093",
+];
+
 /**
  * ランダムなルームIDを生成する
+ * @param ngWords NGワードの配列。指定しない場合はデフォルトのNGワードが使用される
  * @return 生成されたルームID
  */
-export const createRoomID = (): string =>
-  Array.from(
-    { length: ROOM_ID_LENGTH },
-    () => kana[crypto.randomInt(kana.length)],
-  ).join("");
+export const createRoomID = (ngWords: string[] = DEFAULT_NG_WORDS): string => {
+  for (let i = 0; i < MAX_ROOM_CREATION_RETRY; i++) {
+    const roomID = Array.from(
+      { length: ROOM_ID_LENGTH },
+      () => kana[crypto.randomInt(kana.length)],
+    ).join("");
+    const hasNGWord = ngWords.some((ngWord) => roomID.includes(ngWord));
+    if (!hasNGWord) {
+      return roomID;
+    }
+  }
+
+  throw new Error("failed to create room ID after maximum retries");
+};

--- a/packages/ws-signal/src/core/create-room-id.ts
+++ b/packages/ws-signal/src/core/create-room-id.ts
@@ -20,9 +20,6 @@ const kana = [
 /** ルームIDの文字数 */
 const ROOM_ID_LENGTH = 5;
 
-/** ルームIDの最大生成試行回数 */
-const MAX_ROOM_CREATION_RETRY = 5;
-
 /**
  * デフォルトのNGワード
  * NGワードをコードに直接記載するのは憚られたので、Unicodeエスケープシーケンスで記載している
@@ -37,19 +34,19 @@ const DEFAULT_NG_WORDS = [
 /**
  * ランダムなルームIDを生成する
  * @param ngWords NGワードの配列。指定しない場合はデフォルトのNGワードが使用される
- * @return 生成されたルームID
+ * @return 生成されたルームID、または生成に失敗した場合はnull
  */
-export const createRoomID = (ngWords: string[] = DEFAULT_NG_WORDS): string => {
-  for (let i = 0; i < MAX_ROOM_CREATION_RETRY; i++) {
-    const roomID = Array.from(
-      { length: ROOM_ID_LENGTH },
-      () => kana[crypto.randomInt(kana.length)],
-    ).join("");
-    const hasNGWord = ngWords.some((ngWord) => roomID.includes(ngWord));
-    if (!hasNGWord) {
-      return roomID;
-    }
+export const createRoomID = (
+  ngWords: string[] = DEFAULT_NG_WORDS,
+): string | null => {
+  const roomID = Array.from(
+    { length: ROOM_ID_LENGTH },
+    () => kana[crypto.randomInt(kana.length)],
+  ).join("");
+  const hasNGWord = ngWords.some((ngWord) => roomID.includes(ngWord));
+  if (hasNGWord) {
+    return null;
   }
 
-  throw new Error("failed to create room ID after maximum retries");
+  return roomID;
 };

--- a/packages/ws-signal/src/create-room.ts
+++ b/packages/ws-signal/src/create-room.ts
@@ -56,6 +56,10 @@ const dynamoRooms = new DynamoRooms(dynamoDB, DYNAMODB_ROOMS_TABLE);
 async function createRoomWithRetry(connectionId: string, body: CreateRoom) {
   for (let i = 0; i < MAX_ROOM_CREATION_RETRY; i++) {
     const roomID = createRoomID();
+    if (!roomID) {
+      continue;
+    }
+
     const { sdp, iceCandidates } = body;
     const isRoomCreationSuccessful = await dynamoRooms.put({
       roomID,
@@ -66,6 +70,7 @@ async function createRoomWithRetry(connectionId: string, body: CreateRoom) {
       return roomID;
     }
   }
+
   return null;
 }
 

--- a/packages/ws-signal/test/core/create-room-id.test.ts
+++ b/packages/ws-signal/test/core/create-room-id.test.ts
@@ -35,21 +35,8 @@ test("NGワードを含まないルームIDを返す", () => {
   expect(roomID).toBe("かきくけこ");
 });
 
-test("NGワードを含む候補は再生成して返す", () => {
+test("NGワードを含む候補は失敗としてnullを返す", () => {
   kanaIndexes(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
   const roomID = createRoomID(["あい"]);
-  expect(roomID).toBe("かきくけこ");
-});
-
-test("再生成上限までNGワードに一致するとエラーになる", () => {
-  kanaIndexes(
-    ...[0, 1, 2, 3, 4],
-    ...[0, 1, 2, 3, 4],
-    ...[0, 1, 2, 3, 4],
-    ...[0, 1, 2, 3, 4],
-    ...[0, 1, 2, 3, 4],
-  );
-  expect(() => createRoomID(["あい"])).toThrow(
-    "failed to create room ID after maximum retries",
-  );
+  expect(roomID).toBeNull();
 });

--- a/packages/ws-signal/test/core/create-room-id.test.ts
+++ b/packages/ws-signal/test/core/create-room-id.test.ts
@@ -1,0 +1,55 @@
+import { createRoomID } from "../../src/core/create-room-id";
+
+import * as crypto from "crypto";
+
+jest.mock("crypto", () => ({
+  randomInt: jest.fn(),
+}));
+
+/**
+ * モック用のランダムインデックス生成関数
+ * 以下のように、引数に指定したインデックスを順番に返すようにしている
+ * 例: kanaIndexes(0, 1, 2)
+ *     0 -> あ
+ *     1 -> い
+ *     2 -> う
+ * @param indexes 返すインデックスの配列
+ */
+const kanaIndexes = (...indexes: number[]) =>
+  jest.mocked(crypto.randomInt).mockImplementation(() => {
+    const index = indexes.shift();
+    if (index === undefined) {
+      throw new Error("randomInt is called more times than expected");
+    }
+
+    return index;
+  });
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("NGワードを含まないルームIDを返す", () => {
+  kanaIndexes(5, 6, 7, 8, 9);
+  const roomID = createRoomID(["あい", "さし"]);
+  expect(roomID).toBe("かきくけこ");
+});
+
+test("NGワードを含む候補は再生成して返す", () => {
+  kanaIndexes(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+  const roomID = createRoomID(["あい"]);
+  expect(roomID).toBe("かきくけこ");
+});
+
+test("再生成上限までNGワードに一致するとエラーになる", () => {
+  kanaIndexes(
+    ...[0, 1, 2, 3, 4],
+    ...[0, 1, 2, 3, 4],
+    ...[0, 1, 2, 3, 4],
+    ...[0, 1, 2, 3, 4],
+    ...[0, 1, 2, 3, 4],
+  );
+  expect(() => createRoomID(["あい"])).toThrow(
+    "failed to create room ID after maximum retries",
+  );
+});

--- a/packages/ws-signal/test/core/create-room-id.test.ts
+++ b/packages/ws-signal/test/core/create-room-id.test.ts
@@ -1,6 +1,6 @@
-import { createRoomID } from "../../src/core/create-room-id";
-
 import * as crypto from "crypto";
+
+import { createRoomID } from "../../src/core/create-room-id";
 
 jest.mock("crypto", () => ({
   randomInt: jest.fn(),


### PR DESCRIPTION
This pull request enhances the room ID generation logic for both private match rooms and general rooms by adding NG word filtering and improving test coverage. The main updates ensure that generated room IDs do not contain undesirable words, and the generation process will retry up to a maximum number of attempts before failing. Comprehensive tests have also been introduced to verify this behavior.

**Room ID Generation Improvements:**

* Added NG word filtering to `generatePrivateMatchRoomID` in `generate-private-match-room-id.ts` and `createRoomID` in `create-room-id.ts`, with configurable NG word lists and a maximum retry limit to prevent infinite loops. [[1]](diffhunk://#diff-1ec0a291b5c3f34cc3585fbc6df37671c7dd8e3d41f626ae11805ea1b34104c1R25-R61) [[2]](diffhunk://#diff-6b7b504a24f5de64811fa1daa577e3eec0d152782aceb5a27f005afd81c82475R23-R55)
* Introduced a default set of NG words (using Unicode escape sequences) to both room ID generation functions to avoid hardcoding sensitive words directly. [[1]](diffhunk://#diff-1ec0a291b5c3f34cc3585fbc6df37671c7dd8e3d41f626ae11805ea1b34104c1R25-R61) [[2]](diffhunk://#diff-6b7b504a24f5de64811fa1daa577e3eec0d152782aceb5a27f005afd81c82475R23-R55)
* If a valid room ID cannot be generated after the maximum number of retries, an error is thrown to signal failure. [[1]](diffhunk://#diff-1ec0a291b5c3f34cc3585fbc6df37671c7dd8e3d41f626ae11805ea1b34104c1R25-R61) [[2]](diffhunk://#diff-6b7b504a24f5de64811fa1daa577e3eec0d152782aceb5a27f005afd81c82475R23-R55)

**Test Coverage Enhancements:**

* Added unit tests for both `generatePrivateMatchRoomID` and `createRoomID` to verify that NG word filtering and retry logic function as expected, including cases where NG words are present and when the retry limit is exceeded. [[1]](diffhunk://#diff-1f2f63b56aee28cfe8fd39f54785e955e7d23760c47b3ff324e9f05825aa7b8eR1-R55) [[2]](diffhunk://#diff-3e059261a0b9a4056f9283e33073db9a660ac44eca20baa9530fee71d9188c21R1-R55)
* Mocked the random number generation in tests to deterministically control the generated room IDs and ensure reliable test outcomes. [[1]](diffhunk://#diff-1f2f63b56aee28cfe8fd39f54785e955e7d23760c47b3ff324e9f05825aa7b8eR1-R55) [[2]](diffhunk://#diff-3e059261a0b9a4056f9283e33073db9a660ac44eca20baa9530fee71d9188c21R1-R55)